### PR TITLE
Multiple bug fixes

### DIFF
--- a/blockly/generators/propc.js
+++ b/blockly/generators/propc.js
@@ -414,16 +414,7 @@ Blockly.propc.finish = function (code) {
         while (code.match(/\(\(([^()]*)\)\)/g)) {
             code = code.replace(/\(\(([^()]*)\)\)/g, '($1)');
         }
-        
-        // Change strings assigned to variables to strcpy functions
-        code = code.replace(/(\w+)\s*=\s*\({0,1}"(.*)"\){0,1};/g, function(m, p1, p2) {
-            if(p2.indexOf(',') === 0 && p2.indexOf(', "') > -1) {
-                return m;
-            } else {
-                return 'strcpy(' + p1 + ', "' + p2 + '");\t\t\t// Save string into variable ' + p1 + '.';
-            }
-        });
-        
+
         code = 'int main()\n{\n' + setups.join('\n') + '\n' + code + '\n}';
         var setup = '';
         if (Blockly.propc.serial_terminal_) {
@@ -446,12 +437,23 @@ Blockly.propc.finish = function (code) {
             spacer_funcs += '// ------ Functions ------\n';
 
         if (Blockly.propc.definitions_["pure_code"] === '/* PURE CODE ONLY */\n') {
-            return Blockly.propc.methods_["pure_code"];
+            code = Blockly.propc.methods_["pure_code"];
         } else {
-            return setup + allDefs.replace(/\n\n+/g, '\n\n').replace(/\n*$/, '\n\n') +
+            code = setup + allDefs.replace(/\n\n+/g, '\n\n').replace(/\n*$/, '\n\n') +
                     spacer_decs + declarations.join('\n\n').replace(/\n\n+/g, '\n').replace(/\n*$/, '\n') +
                     '\n// ------ Main Program ------\n' + code + spacer_funcs + methods.join('\n');
         }
+
+        // Change strings assigned to variables to strcpy functions
+        code = code.replace(/(\w+)\s*=\s*\({0,1}"(.*)"\){0,1};/g, function(m, p1, p2) {
+            if(p2.indexOf(',') === 0 && p2.indexOf(', "') > -1) {
+                return m;
+            } else {
+                return 'strcpy(' + p1 + ', "' + p2 + '");\t\t\t// Save string into variable ' + p1 + '.';
+            }
+        });
+
+        return code;
     }
 };
 /**

--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -1596,7 +1596,7 @@ Blockly.propc.find_substring = function () {
     } else {
         if (!this.disabled) {
             Blockly.propc.methods_['find_sub_zero'] = 'int str_loc(char *__strS, char *__subS, int __sLoc) { ';
-            Blockly.propc.methods_['find_sub_zero'] += '__sLoc = (sLoc < 0 ? 0 : sLoc);\nsLoc = (__sLoc >= strlen(__strS) ? strlen(__strS) - 1 : sLoc);\n';
+            Blockly.propc.methods_['find_sub_zero'] += '__sLoc = constrainInt(__sLoc, 0, strlen(__strS) - 1);\n';
             Blockly.propc.methods_['find_sub_zero'] += 'char* __pos = strstr(__strS + __sLoc, __subS); return (__pos - __strS); }\n';
             Blockly.propc.method_declarations_["find_sub_zero"] = 'int str_loc(char *, char *, int);\n';
         }
@@ -2410,7 +2410,7 @@ Blockly.propc.constant_value = function () {
 
 
 Blockly.Blocks.custom_code_multiple = {
-    helpUrl: Blockly.MSG_CONTROL_HELPURL,
+    helpUrl: Blockly.MSG_SYSTEM_HELPURL,
     init: function () {
         this.setTooltip(Blockly.MSG_CUSTOM_CODE_MULTIPLE_TOOLTIP);
         this.setColour(colorPalette.getColor('system'));

--- a/blockly/generators/propc/communicate.js
+++ b/blockly/generators/propc/communicate.js
@@ -670,6 +670,10 @@ Blockly.propc.console_print_multiple = function () {
         code = '// ERROR: You cannot use Advanced WX blocks with Simple WX blocks!';
     }
 
+    if (projectData['board'] === 'heb-wx' && this.type === 'wx_print_multiple') {
+        var runInit = Blockly.propc.wx_init_adv();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
+    }
+
     return code;
 };
 
@@ -4617,12 +4621,7 @@ Blockly.Blocks.wx_print_multiple = {
     }
 };
 
-Blockly.propc.wx_print_multiple = function () {
-    if (projectData['board'] === 'heb-wx') {
-        var runInit = Blockly.propc.wx_init_adv();  // Runs the propc generator from the init block, since it's not included in the badge WX board type.
-    }
-    return Blockly.propc.console_print_multiple();
-};
+Blockly.propc.wx_print_multiple = Blockly.propc.console_print_multiple;
 
 Blockly.Blocks.wx_scan_string = {
     helpUrl: Blockly.MSG_AWX_HELPURL,

--- a/blockly/generators/propc/variables.js
+++ b/blockly/generators/propc/variables.js
@@ -190,7 +190,7 @@ Blockly.propc.variables_set = function () {
             Blockly.propc.varlength_[varName] = '{{$var_length_' + varName + '}};';
         } else if (argument0.indexOf("char\[\]") > -1) {
             Blockly.propc.vartype_[varName] = 'char *';
-        } else if (argument0.indexOf("\"") > -1 && argument0.indexOf("get8bitColor(") === -1) {  // Some functions that return numbers take strings as arguments, so we need to account for that.
+        } else if (argument0.indexOf("\"") > -1 && argument0.indexOf("\"") < 4) {  // Some functions that return numbers take strings as arguments, so we need to account for that.
             Blockly.propc.vartype_[varName] = 'char *';
         } else if (argument0.indexOf(".") > -1) {
             Blockly.propc.vartype_[varName] = 'float';


### PR DESCRIPTION
Move regex that changes var = "string" to strcpy(var, "string") to the end of the code generation because this wasn't happening inside of function blocks.

Can't call block generators from other blocks directly - must set them equal, and have the source contain conditional code that generates type specific code instead.

Fix "find string" generated function - typos in internal variable names.

Make string assignment detection a little smarter = it was too aggressive in calling functions with strings as arguments strings when they are returning integers.

