### PR TITLE
Reactivate terminal blocks for badge wx, fixes for upgraded core

### DIFF
--- a/blockly/generators/propc.js
+++ b/blockly/generators/propc.js
@@ -19,7 +19,7 @@
 
 /**
  * @fileoverview Helper functions for generating Prop-c for blocks.
- * @author michel@creatingfuture.eu (Michel Lampo)
+ * @author Matthew Matz, Michel Lampo
  */
 'use strict';
 
@@ -252,16 +252,18 @@ Blockly.propc.init = function (workspace) {
             Blockly.propc.variableDB_.reset();
         }
 
+        //Blockly.propc.variableDB_.setVariableMap(workspace.getVariableMap());    // USE WHEN CORE IS UPDATED
+
         var defvars = [];
         var variables = Blockly.Variables.allVariables(workspace);
+        //var variables = Blockly.Variables.allUsedVarModels(workspace);    // USE WHEN CORE IS UPDATED
         for (var x = 0; x < variables.length; x++) {
             var varName = Blockly.propc.variableDB_.getName(variables[x],
+            //var varName = Blockly.propc.variableDB_.getName(variables[x].getId(),    // USE WHEN CORE IS UPDATED
                     Blockly.Variables.NAME_TYPE);
             defvars[x] = '{{$var_type_' + varName + '}} ' + varName + '{{$var_length_' + varName + '}};';
+            Blockly.propc.definitions_['variable' + x.toString(10)] = defvars[x];
         }
-
-        for (var vardef in defvars)
-            Blockly.propc.definitions_['variable' + vardef.toString(10)] = defvars[vardef];
     }
 };
 /**
@@ -338,8 +340,6 @@ Blockly.propc.finish = function (code) {
         // Exclude variables with "__" in the name for now because those are buffers for private functions
         if (definitions[def].indexOf("char *") > -1 && definitions[def].indexOf("__") === -1 && definitions[def].indexOf("rfidBfr") === -1  && definitions[def].indexOf("wxBuffer") === -1) {
             definitions[def] = definitions[def].replace("char *", "char ").replace(";", "[64];");
-            //definitions[def] = definitions[def].replace(/char \*(\s*)(\w+);/g, 'char *$1$2' + bigStr + spaceAdd + endStr);
-            //spaceAdd += ' ';
         } else if (definitions[def].indexOf("wxBuffer") > -1) {
             definitions[def] = definitions[def].replace("char *", "char ").replace("wxBuffer;", "wxBuffer[64];");
         }
@@ -349,8 +349,6 @@ Blockly.propc.finish = function (code) {
         
         // Sets the length of string arrays based on the lengths specified in the string set length block.
         var vl = Blockly.propc.string_var_lengths.length;
-        //console.log(definitions[def]);
-        //console.log(Blockly.propc.string_var_lengths);
         for (var vt = 0; vt < vl; vt++) {
             var varMatch = new RegExp('char\\s+' + Blockly.propc.string_var_lengths[vt][0] + '\\[');
             if (definitions[def].match(varMatch)) {
@@ -359,8 +357,6 @@ Blockly.propc.finish = function (code) {
         }
 
         for (var method in Blockly.propc.cog_methods_) {
-            console.log(Blockly.propc.methods_[method]);
-            console.log(definitions[def].replace(/[achintr]* \**(\w+)[\[\]0-9]*;/g, '$1'));
             if (Blockly.propc.methods_[method].indexOf(definitions[def].replace(/[achintr]* (\w+)[\[\]0-9]*;/g, '$1')) > -1) {
                 function_vars.push(definitions[def]);
             }
@@ -555,8 +551,25 @@ if (!Object.keys) {
             return result;
         };
     }());
-}
-;
+};
+
+/*
+// NOTE: Replaces core function!                   // USE WHEN CORE IS UPDATED
+Blockly.Field.prototype.render_ = function() {
+    if (!this.visible_) {
+      this.size_.width = 0;
+      return;
+    }
+  
+    // Replace the text.
+    if (this.textElement_) {
+        this.textElement_.textContent = this.getDisplayText_();
+        this.updateWidth();
+    } 
+};
+*/
+
+  
 
 // NOTE: Replaces core function!
 Blockly.BlockSvg.prototype.setCollapsed = function (b) {
@@ -662,49 +675,3 @@ function uniq_fast(a) {
         return tmpOut;
     }
 }
-
-// REPLACES CORE FUNCTION:
-/**
- * Return a sorted list of variable names for variable dropdown menus.
- * Include a special option at the end for creating a new variable name.
- * @return {!Array.<string>} Array of variable names.
- * @this {!Blockly.FieldVariable}
- */
-
-// TODO: use this replacement to allow dropdowns of specific types (number, string, etc.)
-/*
-Blockly.FieldVariable.dropdownCreate = function() {
-  var blockType = null; 
-  if (this.sourceBlock_ && this.sourceBlock_.workspace) {
-    var variableList =
-        Blockly.Variables.allVariables(this.sourceBlock_.workspace);
-    blockType = this.sourceBlock_.type;
-  } else {
-    var variableList = [];
-  }
-  // Ensure that the currently selected variable is an option.
-  var name = this.getText();
-  if (name && variableList.indexOf(name) == -1) {
-    variableList.push(name);
-  }
-  variableList.sort(goog.string.caseInsensitiveCompare);
-  variableList.push(Blockly.Msg.RENAME_VARIABLE);
-  variableList.push(Blockly.Msg.NEW_VARIABLE);
-  // Variables are not language-specific, use the name as both the user-facing
-  // text and the internal representation.
-  var options = [];
-  var z = 0;
-  for (var x = 0; x < variableList.length; x++) {
-    if (blockType !== 'string_var_length') {
-      options[z] = [variableList[x], variableList[x]];
-      z++;
-    } else {
-      if (Blockly.propc.definitions_[name].indexOf('char') === 0) {
-          options[z] = [variableList[x], variableList[x]];
-          z++;
-      }
-    }
-  }
-  return options;
-};
-*/

--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -62,147 +62,166 @@ Blockly.Blocks.math_number = {
                 .setVisible(false);
         this.setOutput(true, 'Number');
         this.connection_id_ = null;
-        this.onchange();
+        this.currentInputType = 'number0';
+        //this.onchange();
     },
-    onchange: function () {
-        var rangeVals = ['N', '-100', '100', '0'];
-        var range = [-100, 100, 0];
-        var data = this.getFieldValue('NUM');
+    onchange: function (event) {
+        if (event.type === Blockly.Events.CHANGE || event.type === Blockly.Events.MOVE) {
+            var rangeVals = ['N', '-100', '100', '0'];
+            var range = [-100, 100, 0];
+            var data = this.getFieldValue('NUM');
 
-        if (this.outputConnection) {
-            if (this.outputConnection.targetBlock() !== null) {
-                var key, inputvalue, _connectedField;
-                var _blockFields = this.outputConnection.targetBlock().getInputWithBlock(this).fieldRow;
-                for (key in _blockFields) {
-                    if (_blockFields.hasOwnProperty(key) && !isNaN(parseInt(key, 10))) {
-                        inputvalue = _blockFields[key].name || ' ';
-                        if (inputvalue.substring(0, 9) === "RANGEVALS") {
-                            _connectedField = inputvalue;
-                            break;
+            if (this.outputConnection) {
+                if (this.outputConnection.targetBlock() !== null) {
+                    var key, inputvalue, _connectedField;
+                    var _blockFields = this.outputConnection.targetBlock().getInputWithBlock(this).fieldRow;
+                    for (key in _blockFields) {
+                        if (_blockFields.hasOwnProperty(key) && !isNaN(parseInt(key, 10))) {
+                            inputvalue = _blockFields[key].name || ' ';
+                            if (inputvalue.substring(0, 9) === "RANGEVALS") {
+                                _connectedField = inputvalue;
+                                break;
+                            }
                         }
                     }
-                }
-                var sourceBlock_ = this.outputConnection.targetBlock();
-                if (sourceBlock_) {
-                    var fieldListing = sourceBlock_.getFieldValue(_connectedField);
-                    if (fieldListing) {
-                        rangeVals = fieldListing.split(',');
-                        if (rangeVals[0] === 'S' || rangeVals[0] === 'R' || rangeVals[0] === 'A') {
-                            var idx;
-                            for (idx = 1; idx <= rangeVals.length; idx++)
-                                range[idx - 1] = Number(rangeVals[idx]);
+                    var sourceBlock_ = this.outputConnection.targetBlock();
+                    if (sourceBlock_) {
+                        var fieldListing = sourceBlock_.getFieldValue(_connectedField);
+                        if (fieldListing) {
+                            rangeVals = fieldListing.split(',');
+                            if (rangeVals[0] === 'S' || rangeVals[0] === 'R' || rangeVals[0] === 'A') {
+                                var idx;
+                                for (idx = 1; idx <= rangeVals.length; idx++)
+                                    range[idx - 1] = Number(rangeVals[idx]);
+                            }
                         }
                     }
-                }
-                if (this.outputConnection.targetBlock().getInputWithBlock(this) !== this.connection_id_) {
-                    var theVal = this.getFieldValue('NUM');
-                    if (this.getInput('MAIN')) {
-                        this.removeInput('MAIN');
+                    if (this.outputConnection.targetBlock().getInputWithBlock(this) !== this.connection_id_) {
+                        var theVal = this.getFieldValue('NUM');
+
+                        if (rangeVals[0] === 'S') {
+                            var theNum = Number(theVal);
+                            if (theNum > range[1])
+                                theNum = range[1];
+                            if (theNum < range[0])
+                                theNum = range[0];
+                            this.setWarningText(null);
+                            
+                            if (this.currentInputType !== 'slider' + range[0].toString(10) + 'to' + range[1].toString(10)) {
+                                if (this.getInput('MAIN')) {
+                                    this.removeInput('MAIN');
+                                }
+                                this.appendDummyInput('MAIN')
+                                        .appendField(new Blockly.FieldRange(theNum.toString(10),
+                                                range[0].toString(10), range[1].toString(10)), 'NUM');
+                                this.currentInputType = 'slider' + range[0].toString(10) + 'to' + range[1].toString(10);
+                            }
+                        } else if (this.currentInputType !== 'number' + theVal) {
+                            if (this.getInput('MAIN')) {
+                                this.removeInput('MAIN');
+                            }
+                            this.appendDummyInput('MAIN')
+                                    .appendField(new Blockly.FieldTextInput(theVal,
+                                            Blockly.FieldTextInput.numberValidator), 'NUM');
+                            this.currentInputType = 'number' + theVal;
+                        }
                     }
-                    if (rangeVals[0] === 'S') {
-                        var theNum = Number(theVal);
-                        if (theNum > range[1])
-                            theNum = range[1];
-                        if (theNum < range[0])
-                            theNum = range[0];
+                    this.connection_id_ = this.outputConnection.targetBlock().getInputWithBlock(this);
+                } else {
+                    if (this.connection_id_) {
+                        var theVal = this.getFieldValue('NUM');
+                        if (this.currentInputType !== 'number' + theVal) {
+                            if (this.getInput('MAIN')) {
+                                this.removeInput('MAIN');
+                            }
+                            this.appendDummyInput('MAIN')
+                                    .appendField(new Blockly.FieldTextInput(theVal,
+                                            Blockly.FieldTextInput.numberValidator), 'NUM');
+                            this.currentInputType = 'number' + theVal;
+                        }
+                    }
+                    this.connection_id_ = null;
+                    rangeVals = ['N', '-100', '100', '0'];
+                }
+            }
+            range[2] = Number(this.getFieldValue('NUM'));
+            if (rangeVals) {
+                if (rangeVals[0] === 'R') {
+                    if (range[2] < range[0]) {
+                        this.setWarningText('WARNING: Your value is too small!  It must be greater than or equal to ' + range[0].toString(10));
+                    } else if (range[2] > range[1]) {
+                        this.setWarningText('WARNING: Your value is too large!  It must be less than or equal to ' + range[1].toString(10));
+                    } else {
                         this.setWarningText(null);
-                        this.appendDummyInput('MAIN')
-                                .appendField(new Blockly.FieldRange(theNum.toString(10),
-                                        range[0].toString(10), range[1].toString(10)), 'NUM');
+                    }
+                } else if (rangeVals[0] === 'A') {
+                    var warnMsg = 'none';
+                    var idx;
+                    for (idx = 0; idx < range.length; idx++)
+                        if (range[2] === Number(rangeVals[idx]))
+                            warnMsg = 'match';
+                    if (warnMsg === 'none') {
+                        this.setWarningText('WARNING: The value you entered is not available or not allowed!');
                     } else {
+                        this.setWarningText(null);
+                    }
+                } else if (rangeVals[0] === 'S') {
+                    this.setWarningText(null);
+                } else {
+                    this.setWarningText(null);
+                }
+                if (rangeVals[0] === 'R' && (range[2] < range[0] || range[2] > range[1]) && Math.abs(range[0] - range[1]) <= 10000000) {
+                    if (this.getField('TITLE')) {
+                        if (range[1] >= 2147483647) {
+                            this.setFieldValue('(\u2265 ' + range[0].toString(10) + ')', 'TITLE');
+                        } else if (range[0] <= -2147483647) {
+                            this.setFieldValue('(\u2264' + range[1].toString(10) + ')', 'TITLE');
+                        } else if (Math.abs(range[0]) === Math.abs(range[1])) {
+                            this.setFieldValue('(+/- ' + Math.abs(range[0]).toString(10) + ')', 'TITLE');
+                        } else {
+                            this.setFieldValue('(' + range[0].toString(10) + ' to ' + range[1].toString(10) + ')', 'TITLE');
+                        }
+                    } else {
+                        if (this.getInput('MAIN')) {
+                            this.removeInput('MAIN');
+                        }
                         this.appendDummyInput('MAIN')
-                                .appendField(new Blockly.FieldTextInput(theVal,
-                                        Blockly.FieldTextInput.numberValidator), 'NUM');
+                                .appendField(new Blockly.FieldTextInput(data,
+                                        Blockly.FieldTextInput.numberValidator), 'NUM')
+                                .appendField('', 'TITLE');
+                        this.currentInputType = 'titlenumber' + data;
+                    }
+                } else {
+                    if (this.getField('TITLE')) {
+                        if (this.getInput('MAIN')) {
+                            this.removeInput('MAIN');
+                        }
+                        if (rangeVals[0] === 'S') {
+                            this.appendDummyInput('MAIN')
+                                    .appendField(new Blockly.FieldRange(data, range[0].toString(10), range[1].toString(10)), 'NUM');
+                            this.currentInputType = 'slider' + range[0].toString(10) + 'to' + range[1].toString(10);
+                        } else {
+                            this.appendDummyInput('MAIN')
+                                    .appendField(new Blockly.FieldTextInput(data,
+                                            Blockly.FieldTextInput.numberValidator), 'NUM');
+                            this.currentInputType = 'number' + data;
+                        }
                     }
                 }
-                this.connection_id_ = this.outputConnection.targetBlock().getInputWithBlock(this);
+                this.setFieldValue(rangeVals.toString(), 'RVALS');
             } else {
-                if (this.connection_id_) {
-                    var theVal = this.getFieldValue('NUM');
-                    if (this.getInput('MAIN')) {
-                        this.removeInput('MAIN');
-                    }
-                    this.appendDummyInput('MAIN')
-                            .appendField(new Blockly.FieldTextInput(theVal,
-                                    Blockly.FieldTextInput.numberValidator), 'NUM');
-                }
-                this.connection_id_ = null;
-                rangeVals = ['N', '-100', '100', '0'];
-            }
-        }
-        range[2] = Number(this.getFieldValue('NUM'));
-        if (rangeVals) {
-            if (rangeVals[0] === 'R') {
-                if (range[2] < range[0]) {
-                    this.setWarningText('WARNING: Your value is too small!  It must be greater than or equal to ' + range[0].toString(10));
-                } else if (range[2] > range[1]) {
-                    this.setWarningText('WARNING: Your value is too large!  It must be less than or equal to ' + range[1].toString(10));
-                } else {
-                    this.setWarningText(null);
-                }
-            } else if (rangeVals[0] === 'A') {
-                var warnMsg = 'none';
-                var idx;
-                for (idx = 0; idx < range.length; idx++)
-                    if (range[2] === Number(rangeVals[idx]))
-                        warnMsg = 'match';
-                if (warnMsg === 'none') {
-                    this.setWarningText('WARNING: The value you entered is not available or not allowed!');
-                } else {
-                    this.setWarningText(null);
-                }
-            } else if (rangeVals[0] === 'S') {
-                this.setWarningText(null);
-            } else {
-                this.setWarningText(null);
-            }
-            if (rangeVals[0] === 'R' && (range[2] < range[0] || range[2] > range[1]) && Math.abs(range[0] - range[1]) <= 10000000) {
                 if (this.getField('TITLE')) {
-                    if (range[1] >= 2147483647) {
-                        this.setFieldValue('(\u2265 ' + range[0].toString(10) + ')', 'TITLE');
-                    } else if (range[0] <= -2147483647) {
-                        this.setFieldValue('(\u2264' + range[1].toString(10) + ')', 'TITLE');
-                    } else if (Math.abs(range[0]) === Math.abs(range[1])) {
-                        this.setFieldValue('(+/- ' + Math.abs(range[0]).toString(10) + ')', 'TITLE');
-                    } else {
-                        this.setFieldValue('(' + range[0].toString(10) + ' to ' + range[1].toString(10) + ')', 'TITLE');
-                    }
-                } else {
                     if (this.getInput('MAIN')) {
                         this.removeInput('MAIN');
                     }
                     this.appendDummyInput('MAIN')
                             .appendField(new Blockly.FieldTextInput(data,
-                                    Blockly.FieldTextInput.numberValidator), 'NUM')
-                            .appendField('', 'TITLE');
+                                    Blockly.FieldTextInput.numberValidator), 'NUM');
+                    this.currentInputType = 'number' + data;
                 }
-            } else {
-                if (this.getField('TITLE')) {
-                    if (this.getInput('MAIN')) {
-                        this.removeInput('MAIN');
-                    }
-                    if (rangeVals[0] === 'S') {
-                        this.appendDummyInput('MAIN')
-                                .appendField(new Blockly.FieldRange(data, range[0].toString(10), range[1].toString(10)), 'NUM');
-                    } else {
-                        this.appendDummyInput('MAIN')
-                                .appendField(new Blockly.FieldTextInput(data,
-                                        Blockly.FieldTextInput.numberValidator), 'NUM');
-                    }
-                }
+                this.setFieldValue('', 'RVALS');
+                this.setWarningText(null);
             }
-            this.setFieldValue(rangeVals.toString(), 'RVALS');
-        } else {
-            if (this.getField('TITLE')) {
-                if (this.getInput('MAIN')) {
-                    this.removeInput('MAIN');
-                }
-                this.appendDummyInput('MAIN')
-                        .appendField(new Blockly.FieldTextInput(data,
-                                Blockly.FieldTextInput.numberValidator), 'NUM');
-            }
-            this.setFieldValue('', 'RVALS');
-            this.setWarningText(null);
         }
     }
 };

--- a/blockly/generators/propc/procedures.js
+++ b/blockly/generators/propc/procedures.js
@@ -660,8 +660,7 @@ Blockly.Blocks['procedures_callreturn'] = {
     },
     getProcedureCall: Blockly.Blocks['procedures_callnoreturn'].getProcedureCall,
     renameProcedure: Blockly.Blocks['procedures_callnoreturn'].renameProcedure,
-    setProcedureParameters_:
-            Blockly.Blocks['procedures_callnoreturn'].setProcedureParameters_,
+    setProcedureParameters_: Blockly.Blocks['procedures_callnoreturn'].setProcedureParameters_,
     updateShape_: Blockly.Blocks['procedures_callnoreturn'].updateShape_,
     mutationToDom: Blockly.Blocks['procedures_callnoreturn'].mutationToDom,
     domToMutation: Blockly.Blocks['procedures_callnoreturn'].domToMutation,
@@ -720,21 +719,14 @@ Blockly.propc.procedures_callreturn = function () {
                 Blockly.propc.ORDER_NONE) || 'null';
     }
     var code = funcName + '(' + args.join(', ') + ')';
-    return [code, Blockly.propc.ORDER_UNARY_POSTFIX];
+    if (this.type === 'procedures_callnoreturn') {
+        return code + ';\n';
+    } else {
+        return [code, Blockly.propc.ORDER_UNARY_POSTFIX];
+    }
 };
 
-Blockly.propc.procedures_callnoreturn = function () {
-    // Call a procedure with no return value.
-    var funcName = Blockly.propc.variableDB_.getName(this.getFieldValue('NAME'),
-            Blockly.Procedures.NAME_TYPE);
-    var args = [];
-    for (var x = 0; x < this.arguments_.length; x++) {
-        args[x] = Blockly.propc.valueToCode(this, 'ARG' + x,
-                Blockly.propc.ORDER_NONE) || 'null';
-    }
-    var code = funcName + '(' + args.join(', ') + ');\n';
-    return code;
-};
+Blockly.propc.procedures_callnoreturn = Blockly.propc.procedures_callreturn;
 
 Blockly.propc.procedures_ifreturn = function () {
     // Conditionally return value from a procedure.

--- a/blockly/generators/propcToolbox.js
+++ b/blockly/generators/propcToolbox.js
@@ -757,7 +757,7 @@ xmlToolbox += '                    </block>';
 xmlToolbox += '                </value>';
 xmlToolbox += '            </block>';
 xmlToolbox += '        </category>';
-xmlToolbox += '        <category key="category_communicate_serial-terminal" exclude="heb-wx,">';
+xmlToolbox += '        <category key="category_communicate_serial-terminal" >';
 xmlToolbox += '            <block type="console_print">';
 xmlToolbox += '                <value name="MESSAGE">';
 xmlToolbox += '                    <block type="string_type_block"></block>';

--- a/editor.js
+++ b/editor.js
@@ -728,7 +728,7 @@ function initToolbox(profileName) {
         grid: {
             spacing: 20,
             length: 5,
-            colour: '#fcfcfc',
+            colour: '#fbfbfb',
             snap: false
         }
     });


### PR DESCRIPTION
 - Re-enables terminal blocks for the Badge WX board type
 - Adds commented out code to propc.js needed after the blockly core is updated related to variables and a replacement of the core's render function that in its original form adversely affects the user defined code block.
 - For the number value block, code is added that restricts when the onchange that displays ranges and warnings is fired, which appears to alleviate an issue where the block appears to jump out of its input.  This issue occurred occasionally in the current version, but when the core is upgraded, appears every time the block was brought from the toolbox to the workspace.
 - Refactors the generators in the procedures.js file