### PR TITLE
 Re-enable graph blocks in badge WX, prep for core upgrade

### DIFF
--- a/blockly/generators/propc.js
+++ b/blockly/generators/propc.js
@@ -352,7 +352,7 @@ Blockly.propc.finish = function (code) {
         for (var vt = 0; vt < vl; vt++) {
             var varMatch = new RegExp('char\\s+' + Blockly.propc.string_var_lengths[vt][0] + '\\[');
             if (definitions[def].match(varMatch)) {
-                definitions[def] = 'char ' + Blockly.propc.string_var_lengths[vt][0] + '[' + Blockly.propc.string_var_lengths[vt][1] + '];';
+                definitions[def] = 'char ' + Blockly.propc.string_var_lengths[vt][0] + '[' + Blockly.propc.string_var_lengths[vt][1] + ' + 1];';
             }
         }
 

--- a/blockly/generators/propc.js
+++ b/blockly/generators/propc.js
@@ -553,22 +553,6 @@ if (!Object.keys) {
     }());
 };
 
-/*
-// NOTE: Replaces core function!                   // USE WHEN CORE IS UPDATED
-Blockly.Field.prototype.render_ = function() {
-    if (!this.visible_) {
-      this.size_.width = 0;
-      return;
-    }
-  
-    // Replace the text.
-    if (this.textElement_) {
-        this.textElement_.textContent = this.getDisplayText_();
-        this.updateWidth();
-    } 
-};
-*/
-
   
 
 // NOTE: Replaces core function!

--- a/blockly/generators/propc/variables.js
+++ b/blockly/generators/propc/variables.js
@@ -45,41 +45,6 @@ Blockly.Blocks.variables_get = {
         this.setOutput(true);
         this.typeCheckRun = null;
     },
-    /*
-    onchange: function () {
-        var sBlock = this;
-        if(!this.typeCheckRun) {
-            this.typeCheckRun = setTimeout(function () {
-                var outType = "Number";
-                var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
-                for (var x = 0; x < allBlocks.length; x++) {
-                    var func = allBlocks[x].getVarType;
-                    var fund = allBlocks[x].getVars;
-                    if (func) {
-                        var blockType = func.call(allBlocks[x]);
-                        var blockVars = fund.call(allBlocks[x]);
-                        var varMatch = false;
-                        for (var y = 0; y < blockVars.length; y++) {
-                            if (blockVars[y].toString() === sBlock.getFieldValue('VAR')) {
-                                varMatch = true;
-                                break;
-                            }
-                        }
-                        if (blockType === 'String' && varMatch) {
-                            var outType = "String";
-                            break;
-                        } else if (blockType === 'Number' && varMatch) {
-                            var outType = "Number";
-                            break;
-                        }
-                    }
-                }
-                sBlock.typeCheckRun = null;
-                sBlock.setOutput(true, outType);
-            }, 500);
-        }
-    },
-    */
     getVars: function () {
         return [this.getFieldValue('VAR')];
     },
@@ -89,33 +54,6 @@ Blockly.Blocks.variables_get = {
         }
     }
 };
-
-/*
-Blockly.Blocks.variables_declare = {
-    // Variable setter.
-    init: function () {
-        this.setColour(colorPalette.getColor('variables'));
-        this.appendValueInput('VALUE', null)
-                .appendField('Declare')
-                .appendField(new Blockly.FieldVariable(
-                        Blockly.LANG_VARIABLES_SET_ITEM), 'VAR')
-                .appendField("as")
-                .appendField(new Blockly.FieldDropdown([["int", "int"], ["float", "float"], ["char", "char"], ["unsigned int", "unsigned int"], ["signed char", "signed char"]]), "TYPE")
-                .appendField("value");
-
-        this.setPreviousStatement(true, "Block");
-        this.setNextStatement(true);
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
-    }
-};
-*/
 
 Blockly.Blocks.variables_set = {
     // Variable setter.
@@ -130,6 +68,7 @@ Blockly.Blocks.variables_set = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true);
     },
+    /*
     getVarType: function () {
         if (this.getInputTargetBlock('VALUE')) {
             return this.getInputTargetBlock('VALUE').outputConnection.check_.toString();
@@ -137,6 +76,7 @@ Blockly.Blocks.variables_set = {
             return null;
         }
     },
+    */
     getVars: function () {
         return [this.getFieldValue('VAR')];
     },
@@ -145,6 +85,7 @@ Blockly.Blocks.variables_set = {
             this.setFieldValue(newName, 'VAR');
         }
     }
+
 };
 
 Blockly.propc.variables_get = function () {
@@ -155,21 +96,6 @@ Blockly.propc.variables_get = function () {
     return [code, Blockly.propc.ORDER_ATOMIC];
 };
 
-/*
-Blockly.propc.variables_declare = function () {
-    // Variable setter.
-    var dropdown_type = this.getFieldValue('TYPE');
-    //TODO: settype to variable
-    var argument0 = Blockly.propc.valueToCode(this, 'VALUE',
-            Blockly.propc.ORDER_ASSIGNMENT) || '0';
-    var varName = Blockly.propc.variableDB_.getName(
-            this.getFieldValue('VAR'),
-            Blockly.Variables.NAME_TYPE);
-    Blockly.propc.setups_['setup_var' + varName] = varName + ' = ' + argument0 + ';';
-    Blockly.propc.vartype_[varName] = dropdown_type;
-    return '';
-};
-*/
 
 Blockly.propc.variables_set = function () {
     // Variable setter.

--- a/blockly/generators/propcToolbox.js
+++ b/blockly/generators/propcToolbox.js
@@ -395,7 +395,7 @@ xmlToolbox += '            </block>';
 xmlToolbox += '            <block type="heb_ir_read_signal"></block>';
 xmlToolbox += '            <block type="heb_ir_clear_buffer"></block>';
 xmlToolbox += '        </category>';
-xmlToolbox += '        <category key="category_communicate_graphing" exclude="heb-wx,">';
+xmlToolbox += '        <category key="category_communicate_graphing" >';
 xmlToolbox += '            <block type="graph_settings">';
 xmlToolbox += '                <field name="XAXIS">40,S</field>';
 xmlToolbox += '            </block>';

--- a/blockly/language/en/_messages.js
+++ b/blockly/language/en/_messages.js
@@ -67,6 +67,7 @@ Blockly.MSG_RENAME_VARIABLE_TITLE = 'Rename all "%1" variables to:';
 Blockly.LANG_VARIABLES_SET_ITEM = 'item';
 Blockly.LANG_VARIABLES_GET_ITEM = 'item';
 
+
 // Control Blocks.
 Blockly.LANG_CATEGORY_CONTROLS = 'Control';
 Blockly.LANG_CONTROLS_IF_MSG_IF = 'if';
@@ -176,6 +177,7 @@ Blockly.Msg.PROCEDURES_MUTATORCONTAINER_TITLE = "inputs";
 Blockly.Msg.REDO = "Redo";
 Blockly.Msg.REMOVE_COMMENT = "Remove Comment";
 Blockly.Msg.RENAME_VARIABLE = "Rename variable...";
+Blockly.Msg.DELETE_VARIABLE = "Delete variable %1";
 Blockly.Msg.RENAME_VARIABLE_TITLE = "Rename all '%1' variables to:";
 
 Blockly.Msg.TODAY = "Today";

--- a/blocklyc.js
+++ b/blocklyc.js
@@ -181,7 +181,9 @@ function renderContent(pane) {
         codeXml.setValue(xmlText);
         codeXml.gotoLine(0);
     } else if (pane === 'propc' && projectData['board'] !== 'propcfile') {
-        prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
+        var raw_c = prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
+        codePropC.setValue(raw_c);
+        codePropC.gotoLine(0);
     } else if (pane === 'propc') {
         if (codePropC.getValue() === '') {
             codePropC.setValue(atob((projectData['code'].match(/<field name="CODE">(.*)<\/field>/) || ['', ''])[1] || ''));
@@ -193,7 +195,9 @@ function renderContent(pane) {
             blankProjectCode += '// ------ Global Variables and Objects ------\n\n\n';
             blankProjectCode += '// ------ Main Program ------\n';
             blankProjectCode += 'int main() {\n\n\nwhile (1) {\n\n\n}}';
-            prettyCode(blankProjectCode);
+            var raw_c = prettyCode(blankProjectCode);
+            codePropC.setValue(raw_c);
+            codePropC.gotoLine(0);
         }   
     }
 }
@@ -230,8 +234,7 @@ var prettyCode = function (raw_code) {
                 return "[" + m1 + "] = {" + m2 + "};";
             });
 
-    codePropC.setValue(raw_code);
-    codePropC.gotoLine(0);
+    return (raw_code);
 };
 
 var findReplaceCode = function () {
@@ -310,7 +313,7 @@ function cloudCompile(text, action, successHandler) {
     // if PropC is in edit mode, get it from the editor, otherwise render it from the blocks.
     var propcCode = '';
     if (codePropC.getReadOnly()) {
-        propcCode = Blockly.propc.workspaceToCode(Blockly.mainWorkspace);
+        propcCode = prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
     } else {
         propcCode = codePropC.getValue();
     }
@@ -322,12 +325,6 @@ function cloudCompile(text, action, successHandler) {
         $("#compile-dialog-title").text(text);
         $("#compile-console").val('Compile... ');
         $('#compile-dialog').modal('show');
-
-
-        propcCode = js_beautify(propcCode, {
-            'brace_style': 'expand',
-            'indent_size': 2
-        });
 
         var terminalNeeded = false;
         if (propcCode.indexOf("SERIAL_TERMINAL USED") > -1)

--- a/editor.js
+++ b/editor.js
@@ -734,6 +734,7 @@ function initToolbox(profileName) {
     });
 
     init(Blockly);
+    //Blockly.mainWorkspace.createVariable('item');      // USE AFTER CORE IS REPLACED
 }
 
 function loadToolbox(xmlText) {

--- a/style-editor.css
+++ b/style-editor.css
@@ -27,8 +27,9 @@ html, body {
     position: absolute; /* Safari height clipping fix */
 }
 
-.blocklyWidgetDiv .goog-menuitem-content {
+.blocklyWidgetDiv .goog-menuitem-content, .blocklyContextMenu, .blocklydropdownmenu {
     font: normal 14px Arimo, sans-serif !important;
+    max-height: 110% !important;
 }
 
 .field_code {


### PR DESCRIPTION
Also, 
 - Matches code beautify in compile to beautify in display so that line numbers in compile error messages match up.
 - Fixes and improves the string length block.
 -- was not working correctly before (didn't save properly, bugs on reload.
 -- now allows for named constants to define lengths, too.