### PR TITLE
Remove unecessary getVar and renameVar functions

### DIFF
--- a/blockly/generators/propc.js
+++ b/blockly/generators/propc.js
@@ -554,7 +554,6 @@ if (!Object.keys) {
 };
 
 
-
 // NOTE: Replaces core function!                   // USE WHEN CORE IS UPDATED
 Blockly.Field.prototype.render_ = function() {
     if (!this.visible_) {
@@ -567,56 +566,6 @@ Blockly.Field.prototype.render_ = function() {
         this.textElement_.textContent = this.getDisplayText_();
         this.updateWidth();
     } 
-};
-
-// NOTE: Replaces core function!                   // USE WHEN CORE IS UPDATED
-/**
- * Return a sorted list of variable names for variable dropdown menus.
- * Include a special option at the end for creating a new variable name.
- * @return {!Array.<string>} Array of variable names.
- * @this {Blockly.FieldVariable}
- */
-Blockly.FieldVariable.dropdownCreate = function() {
-    if (!this.variable_) {
-      throw new Error('Tried to call dropdownCreate on a variable field with no' +
-          ' variable selected.');
-    }
-    var name = this.getText();
-    var workspace = null;
-    if (this.sourceBlock_) {
-      workspace = this.sourceBlock_.workspace;
-    }
-    var variableModelList = [];
-    if (workspace) {
-      var variableTypes = this.getVariableTypes_();
-      // Get a copy of the list, so that adding rename and new variable options
-      // doesn't modify the workspace's list.
-      for (var i = 0; i < variableTypes.length; i++) {
-        var variableType = variableTypes[i];
-        var variables = workspace.getVariablesOfType(variableType);
-        variableModelList = variableModelList.concat(variables);
-      }
-    }
-    variableModelList.sort(Blockly.VariableModel.compareByName);
-  
-    var options = [];
-    for (var i = 0; i < variableModelList.length; i++) {
-      // Set the UUID as the internal representation of the variable.
-      options[i] = [variableModelList[i].name, variableModelList[i].getId()];
-    }
-    if (name !== Blockly.LANG_VARIABLES_SET_ITEM) {
-        options.push([Blockly.Msg['RENAME_VARIABLE'], Blockly.RENAME_VARIABLE_ID]);
-    }
-    if (Blockly.Msg['DELETE_VARIABLE'] && name !== Blockly.LANG_VARIABLES_SET_ITEM) {   // Prevents user from deleting the default "item" variable.
-      options.push(
-          [
-            Blockly.Msg['DELETE_VARIABLE'].replace('%1', name),
-            Blockly.DELETE_VARIABLE_ID
-          ]
-      );
-    }
-  
-    return options;
 };
 
 

--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -1616,7 +1616,7 @@ Blockly.Blocks.combine_strings = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
+    }
 };
 
 Blockly.propc.combine_strings = function () {

--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -1115,20 +1115,6 @@ Blockly.Blocks.string_var_length = {
             }
         }
     },
-    getVars: function () {
-        var theVars = [];
-        for (var i = 0; i < this.myChildren_; i++) {
-            theVars.push(this.getFieldValue('VAR_NAME' + i.toString(10)));
-        }
-        return theVars;
-    },
-    renameVar: function (oldName, newName) {
-        for (var i = 0; i < this.myChildren_; i++) {
-            if (Blockly.Names.equals(oldName, this.getFieldValue('VAR_NAME' + i.toString(10)))) {
-                this.setFieldValue(newName, 'VAR_NAME' + i.toString(10));
-            }
-        }
-    },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
         var strVarBlocksCount = 0;
@@ -1631,17 +1617,6 @@ Blockly.Blocks.combine_strings = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
     },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
-    }
 };
 
 Blockly.propc.combine_strings = function () {
@@ -1750,14 +1725,6 @@ Blockly.Blocks.get_char_at_position = {
                 .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'VALUE');
         this.setInputsInline(true);
         this.setOutput(true, "Number");
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
 };
 
@@ -1802,17 +1769,6 @@ Blockly.Blocks.set_char_at_position = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
 };
 
@@ -1866,18 +1822,6 @@ Blockly.Blocks.get_substring = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('FROM_STR'), this.getFieldValue('TO_STR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('FROM_STR')))
-            this.setFieldValue(newName, 'FROM_STR');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('TO_STR')))
-            this.setFieldValue(newName, 'TO_STR');
     }
 };
 
@@ -1970,14 +1914,6 @@ Blockly.Blocks.string_to_number = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     }
 };
 
@@ -2012,17 +1948,6 @@ Blockly.Blocks.number_to_string = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     }
 };
 
@@ -2064,16 +1989,6 @@ Blockly.Blocks.string_split = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('TO_STR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('TO_STR')))
-            this.setFieldValue(newName, 'TO_STR');
     }
 };
 
@@ -2137,18 +2052,6 @@ Blockly.Blocks.string_trim = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('FROM_STR'), this.getFieldValue('TO_STR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('FROM_STR')))
-            this.setFieldValue(newName, 'FROM_STR');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('TO_STR')))
-            this.setFieldValue(newName, 'TO_STR');
     }
 };
 
@@ -2304,14 +2207,6 @@ Blockly.Blocks.math_advanced = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('STORE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('STORE'))) {
-            this.setFieldValue(newName, 'STORE');
-        }
     }
 };
 
@@ -2354,14 +2249,6 @@ Blockly.Blocks.math_inv_trig = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('STORE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('STORE'))) {
-            this.setFieldValue(newName, 'STORE');
-        }
     }
 };
 

--- a/blockly/generators/propc/communicate.js
+++ b/blockly/generators/propc/communicate.js
@@ -696,19 +696,7 @@ Blockly.Blocks.console_scan_text = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
-
 };
 
 Blockly.propc.console_scan_text = function () {
@@ -738,16 +726,7 @@ Blockly.Blocks.console_scan_number = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
-
 };
 
 Blockly.propc.console_scan_number = function () {
@@ -1201,19 +1180,6 @@ Blockly.Blocks.serial_receive_text = {
     domToMutation: Blockly.Blocks['serial_send_text'].domToMutation,
     serPins: Blockly.Blocks['serial_send_text'].serPins,
     updateSerPin: Blockly.Blocks['serial_send_text'].updateSerPin,
-    getVarType: function () {
-        if (this.getFieldValue('TYPE') === 'TEXT') {
-            return "String";
-        }
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
-    },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
         if (allBlocks.indexOf('Serial initialize') === -1)
@@ -1655,19 +1621,6 @@ Blockly.Blocks.serial_scan_multiple = {
             warnTxt = 'Serial recieve must have at least one search term.';
         }
         this.setWarningText(warnTxt);
-    },
-    getVars: function () {
-        var theVars = [];
-        for (var i = 0; i < this.optionList_.length; i++) {
-            theVars.push(this.getFieldValue('CPU' + i));
-        }
-        return theVars;
-    },
-    renameVar: function (oldName, newName) {
-        for (var i = 0; i < this.optionList_.length; i++) {
-            if (Blockly.Names.equals(oldName, this.getFieldValue('CPU' + i)))
-                this.setFieldValue(newName, 'CPU' + i);
-        }
     }
 };
 
@@ -1769,14 +1722,6 @@ Blockly.Blocks.serial_rx = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
         this.setWarningText('WARNING: This block has been deprecated\nand may not work correctly!\nPlease use one of the blocks\navailable in the menu.');
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
 };
 
@@ -2581,19 +2526,6 @@ Blockly.Blocks.xbee_receive = {
         } else {
             this.setWarningText(null);
         }
-    },
-    getVarType: function () {
-        if (this.getFieldValue('TYPE') === 'TEXT') {
-            return "String";
-        }
-    },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
     }
 };
 
@@ -2700,19 +2632,6 @@ Blockly.Blocks.xbee_scan_multiple = {
             warnTxt = 'XBee recieve must have at least one search term.';
         }
         this.setWarningText(warnTxt);
-    },
-    getVars: function () {
-        var theVars = [];
-        for (var i = 0; i < this.optionList_.length; i++) {
-            theVars.push(this.getFieldValue('CPU' + i));
-        }
-        return theVars;
-    },
-    renameVar: function (oldName, newName) {
-        for (var i = 0; i < this.optionList_.length; i++) {
-            if (Blockly.Names.equals(oldName, this.getFieldValue('CPU' + i)))
-                this.setFieldValue(newName, 'CPU' + i);
-        }
     }
 };
 
@@ -4538,22 +4457,6 @@ Blockly.Blocks.wx_scan_multiple = {
             }
             this.setWarningText(warnTxt);
         }
-    },
-    getVars: function () {
-        var theVars = [this.getFieldValue('HANDLE')];
-        for (var i = 0; i < this.optionList_.length; i++) {
-            theVars.push(this.getFieldValue('CPU' + i));
-        }
-        return theVars;
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setFieldValue(newName, 'HANDLE');
-        for (var i = 0; i < this.optionList_.length; i++) {
-            if (Blockly.Names.equals(oldName, this.getFieldValue('CPU' + i)))
-                this.setFieldValue(newName, 'CPU' + i);
-
-        }
     }
 };
 
@@ -4638,15 +4541,7 @@ Blockly.Blocks.wx_print_multiple = {
     decompose: Blockly.Blocks['console_print_multiple'].decompose,
     compose: Blockly.Blocks['serial_print_multiple'].compose,
     saveConnections: Blockly.Blocks['console_print_multiple'].saveConnections,
-    onchange: Blockly.Blocks['wx_scan_multiple'].onchange,
-    getVars: function () {
-        return [this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE'))) {
-            this.setFieldValue(newName, 'HANDLE');
-        }
-    }
+    onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
 
 Blockly.propc.wx_print_multiple = Blockly.propc.console_print_multiple;
@@ -4688,15 +4583,6 @@ Blockly.Blocks.wx_scan_string = {
         this.appendDummyInput('STORE')
                 .appendField('store string in')
                 .appendField(new Blockly.FieldVariable(data), 'VARNAME');
-    },
-    getVars: function () {
-        return [this.getFieldValue('VARNAME'), this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setFieldValue(newName, 'HANDLE');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VARNAME')))
-            this.setFieldValue(newName, 'VARNAME');
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks();
@@ -4770,14 +4656,6 @@ Blockly.Blocks.wx_send_string = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
     },
-    getVars: function () {
-        return [this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE'))) {
-            this.setFieldValue(newName, 'HANDLE');
-        }
-    },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
 
@@ -4820,17 +4698,6 @@ Blockly.Blocks.wx_receive_string = {
         this.setNextStatement(true, null);
         this.setInputsInline(false);
     },
-    getVars: function () {
-        return [this.getFieldValue('DATA'), this.getFieldValue('BYTES'), this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('DATA')))
-            this.setFieldValue(newName, 'DATA');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('BYTES')))
-            this.setFieldValue(newName, 'BYTES');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setFieldValue(newName, 'HANDLE');
-    },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
 
@@ -4869,17 +4736,6 @@ Blockly.Blocks.wx_poll = {
                 .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'HANDLE');
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('ID'), this.getFieldValue('EVENT'), this.getFieldValue('HANDLE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('ID')))
-            this.setFieldValue(newName, 'ID');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('EVENT')))
-            this.setFieldValue(newName, 'EVENT');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HANDLE')))
-            this.setFieldValue(newName, 'HANDLE');
     },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
@@ -4967,27 +4823,6 @@ Blockly.Blocks.wx_listen = {
             this.getInput('CONNVARS').setVisible(false);
         }
         this.getInput('PORT').setVisible(prefixVisible);
-    },
-    getVars: function () {
-        if (this.getFieldValue('PROTOCOL') !== 'TCP') {
-            return [this.getFieldValue('ID'), this.getFieldValue('ID1'), this.getFieldValue('ID2'), this.getFieldValue('ID3'), this.getFieldValue('ID4')];
-        } else {
-            return [this.getFieldValue('ID')];
-        }
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('ID')))
-            this.setFieldValue(newName, 'ID');
-        if (this.getFieldValue('PROTOCOL') !== 'TCP') {
-            if (Blockly.Names.equals(oldName, this.getFieldValue('ID1')))
-                this.setFieldValue(newName, 'ID1');
-            if (Blockly.Names.equals(oldName, this.getFieldValue('ID2')))
-                this.setFieldValue(newName, 'ID2');
-            if (Blockly.Names.equals(oldName, this.getFieldValue('ID3')))
-                this.setFieldValue(newName, 'ID3');
-            if (Blockly.Names.equals(oldName, this.getFieldValue('ID4')))
-                this.setFieldValue(newName, 'ID4');
-        }
     },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
@@ -5237,17 +5072,6 @@ Blockly.Blocks.wx_buffer = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
     },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('BUFFER')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setFieldValue(newName, 'BUFFER');
-        }
-    },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
 };
 
@@ -5303,14 +5127,6 @@ Blockly.Blocks.wx_disconnect = {
         } else {
             this.setFieldValue('wxId', 'ID');
             this.setFieldValue('ID', 'TEXT');
-        }
-    },
-    getVars: function () {
-        return [this.getFieldValue('ID')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('ID'))) {
-            this.setFieldValue(newName, 'ID');
         }
     },
     onchange: Blockly.Blocks['wx_scan_multiple'].onchange
@@ -6121,14 +5937,6 @@ Blockly.Blocks.i2c_receive = {
             this.setFieldValue(m2, 'SCL');
         }
     },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
-    },
     mutationToDom: Blockly.Blocks['i2c_send'].mutationToDom,
     domToMutation: Blockly.Blocks['i2c_send'].domToMutation,
     checkI2cPins: Blockly.Blocks['i2c_send'].checkI2cPins
@@ -6345,9 +6153,7 @@ Blockly.Blocks.string_scan_multiple = {
     compose: Blockly.Blocks['serial_scan_multiple'].compose,
     saveConnections: Blockly.Blocks['serial_scan_multiple'].saveConnections,
     updateShape_: Blockly.Blocks['serial_scan_multiple'].updateShape_,
-    updateSerPin: function () {},
-    getVars: Blockly.Blocks['wx_scan_multiple'].getVars,
-    renameVar: Blockly.Blocks['wx_scan_multiple'].renameVar
+    updateSerPin: function () {}
 };
 
 Blockly.Blocks.string_scan_container = {
@@ -6442,15 +6248,7 @@ Blockly.Blocks.string_sprint_multiple = {
     domToMutation: Blockly.Blocks['console_print_multiple'].domToMutation,
     decompose: Blockly.Blocks['console_print_multiple'].decompose,
     compose: Blockly.Blocks['console_print_multiple'].compose,
-    saveConnections: Blockly.Blocks['console_print_multiple'].saveConnections,
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
-    }
+    saveConnections: Blockly.Blocks['console_print_multiple'].saveConnections
 };
 
 Blockly.propc.string_sprint_multiple = Blockly.propc.console_print_multiple;

--- a/blockly/generators/propc/control.js
+++ b/blockly/generators/propc/control.js
@@ -385,7 +385,7 @@ Blockly.Blocks.control_repeat_for_loop = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
         this.setInputsInline(true);
-    },
+    }
 };
 
 Blockly.propc.control_repeat_for_loop = function () {

--- a/blockly/generators/propc/control.js
+++ b/blockly/generators/propc/control.js
@@ -386,14 +386,6 @@ Blockly.Blocks.control_repeat_for_loop = {
         this.setNextStatement(true, null);
         this.setInputsInline(true);
     },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
-    }
 };
 
 Blockly.propc.control_repeat_for_loop = function () {

--- a/blockly/generators/propc/gpio.js
+++ b/blockly/generators/propc/gpio.js
@@ -652,14 +652,7 @@ Blockly.Blocks.eeprom_read = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        if (this.getFieldValue('TYPE') === 'TEXT') {
-            return "String";
-        } else {
-            return "Number";
-        }
-    },
+    }
 };
 
 Blockly.propc.eeprom_read = function () {

--- a/blockly/generators/propc/gpio.js
+++ b/blockly/generators/propc/gpio.js
@@ -660,14 +660,6 @@ Blockly.Blocks.eeprom_read = {
             return "Number";
         }
     },
-    getVars: function () {
-        return [this.getFieldValue('VALUE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VALUE'))) {
-            this.setFieldValue(newName, 'VALUE');
-        }
-    }
 };
 
 Blockly.propc.eeprom_read = function () {
@@ -1709,18 +1701,6 @@ Blockly.Blocks.sd_read = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        if(this.getField('VAR')) {
-            return [this.getFieldValue('VAR')];
-        } else {
-            return [];
-        }
-    },
-    renameVar: function (oldName, newName) {
-        if (this.getField('VAR') && Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     },
     mutationToDom: function () {
         var container = document.createElement('mutation');

--- a/blockly/generators/propc/heb.js
+++ b/blockly/generators/propc/heb.js
@@ -611,15 +611,6 @@ Blockly.Blocks.heb_ir_read_signal = {
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true);
         this.setInputsInline(true);
-    },
-    getVars: function () {
-        return [this.getFieldValue('BUFFER'), this.getFieldValue('LENGTH')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER')))
-            this.setFieldValue(newName, 'BUFFER');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('LENGTH')))
-            this.setFieldValue(newName, 'LENGTH');
     }
 };
 
@@ -707,17 +698,6 @@ Blockly.Blocks.heb_badge_eeprom_retrieve = {
                 .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_SET_ITEM), 'BUFFER');
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVarType: function () {
-        return "String";
-    },
-    getVars: function () {
-        return [this.getFieldValue('BUFFER')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setFieldValue(newName, 'BUFFER');
-        }
     }
 };
 

--- a/blockly/generators/propc/s3.js
+++ b/blockly/generators/propc/s3.js
@@ -1537,7 +1537,7 @@ Blockly.Blocks.s3_eeprom_read = {
         this.setInputsInline(true);
         this.setOutput(true, 'Number');
         this.setColour(colorPalette.getColor('output'));
-  }
+    }
 };
 
 Blockly.propc.s3_eeprom_read = function () {

--- a/blockly/generators/propc/sensors.js
+++ b/blockly/generators/propc/sensors.js
@@ -426,18 +426,6 @@ Blockly.Blocks.colorpal_get_colors_raw = {
         }
         this.cp_pins = uniq_fast(this.cp_pins);
     },
-    getVars: function () {
-        return [this.getFieldValue('R_STORAGE'), this.getFieldValue('G_STORAGE'), this.getFieldValue('B_STORAGE')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('R_STORAGE'))) {
-            this.setFieldValue(newName, 'R_STORAGE');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('G_STORAGE'))) {
-            this.setFieldValue(newName, 'G_STORAGE');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('B_STORAGE'))) {
-            this.setFieldValue(newName, 'B_STORAGE');
-        }
-    },
     onchange: function (event) {
         // only fire when a block got deleted or created, the CP_PIN field was changed
         if (event.oldXml || event.type === Blockly.Events.CREATE || (event.name === 'CP_PIN' && event.blockId === this.id) || this.warnFlag > 0) {
@@ -507,14 +495,6 @@ Blockly.Blocks.colorpal_get_colors = {
     colorpalPins: Blockly.Blocks['colorpal_get_colors_raw'].colorpalPins,
     updateCpin: Blockly.Blocks['colorpal_get_colors_raw'].updateCpin,
     onchange: Blockly.Blocks['colorpal_get_colors_raw'].onchange,
-    getVars: function () {
-        return [this.getFieldValue('COLOR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('COLOR'))) {
-            this.setFieldValue(newName, 'COLOR');
-        }
-    }
 };
 
 Blockly.propc.colorpal_get_colors = function () {
@@ -890,18 +870,6 @@ Blockly.Blocks.MMA7455_acceleration = {
         this.setNextStatement(true, null);
         this.setPreviousStatement(true, "Block");
     },
-    getVars: function () {
-        return [this.getFieldValue('X_VAR'), this.getFieldValue('Y_VAR'), this.getFieldValue('Z_VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('X_VAR'))) {
-            this.setFieldValue(newName, 'X_VAR');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('Y_VAR'))) {
-            this.setFieldValue(newName, 'Y_VAR');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('Z_VAR'))) {
-            this.setFieldValue(newName, 'Z_VAR');
-        }
-    },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
         if (allBlocks.indexOf('Accelerometer initialize') === -1)
@@ -971,14 +939,6 @@ Blockly.Blocks.HMC5883L_read = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('HEADING')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('HEADING'))) {
-            this.setFieldValue(newName, 'HEADING');
-        }
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
@@ -1113,18 +1073,6 @@ Blockly.Blocks.lsm9ds1_read = {
         this.setNextStatement(true, null);
         this.setPreviousStatement(true, "Block");
     },
-    getVars: function () {
-        return [this.getFieldValue('X_VAR'), this.getFieldValue('Y_VAR'), this.getFieldValue('Z_VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('X_VAR'))) {
-            this.setFieldValue(newName, 'X_VAR');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('Y_VAR'))) {
-            this.setFieldValue(newName, 'Y_VAR');
-        } else if (Blockly.Names.equals(oldName, this.getFieldValue('Z_VAR'))) {
-            this.setFieldValue(newName, 'Z_VAR');
-        }
-    },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
         if (allBlocks.indexOf('IMU initialize') === -1)
@@ -1219,15 +1167,6 @@ Blockly.Blocks.lsm9ds1_tilt = {
         }
         this.setFieldValue(theVar1, 'VAR1');
         this.setFieldValue(theVar2, 'VAR2');
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR1'), this.getFieldValue('VAR2')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR1')))
-            this.setFieldValue(newName, 'VAR1');
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR2')))
-            this.setFieldValue(newName, 'VAR2');
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
@@ -1340,14 +1279,6 @@ Blockly.Blocks.lsm9ds1_heading = {
                     .appendField(new Blockly.FieldVariable(Blockly.LANG_VARIABLES_GET_ITEM), 'VAR');
         }
         this.setFieldValue(theVar, 'VAR');
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();
@@ -1801,14 +1732,6 @@ Blockly.Blocks.rfid_get = {
 
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
-    },
-    getVars: function () {
-        return [this.getFieldValue('BUFFER')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('BUFFER'))) {
-            this.setFieldValue(newName, 'BUFFER');
-        }
     },
     onchange: function () {
         var allBlocks = Blockly.getMainWorkspace().getAllBlocks().toString();

--- a/blockly/generators/propc/sensors.js
+++ b/blockly/generators/propc/sensors.js
@@ -494,7 +494,7 @@ Blockly.Blocks.colorpal_get_colors = {
     domToMutation: Blockly.Blocks['colorpal_get_colors_raw'].domToMutation,
     colorpalPins: Blockly.Blocks['colorpal_get_colors_raw'].colorpalPins,
     updateCpin: Blockly.Blocks['colorpal_get_colors_raw'].updateCpin,
-    onchange: Blockly.Blocks['colorpal_get_colors_raw'].onchange,
+    onchange: Blockly.Blocks['colorpal_get_colors_raw'].onchange
 };
 
 Blockly.propc.colorpal_get_colors = function () {

--- a/blockly/generators/propc/variables.js
+++ b/blockly/generators/propc/variables.js
@@ -44,14 +44,6 @@ Blockly.Blocks.variables_get = {
                         Blockly.LANG_VARIABLES_GET_ITEM), 'VAR');
         this.setOutput(true);
         this.typeCheckRun = null;
-    },
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     }
 };
 
@@ -67,25 +59,7 @@ Blockly.Blocks.variables_set = {
                 .appendField('=');
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true);
-    },
-    /*
-    getVarType: function () {
-        if (this.getInputTargetBlock('VALUE')) {
-            return this.getInputTargetBlock('VALUE').outputConnection.check_.toString();
-        } else {
-            return null;
-        }
-    },
-    */
-    getVars: function () {
-        return [this.getFieldValue('VAR')];
-    },
-    renameVar: function (oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-            this.setFieldValue(newName, 'VAR');
-        }
     }
-
 };
 
 Blockly.propc.variables_get = function () {

--- a/blockly/language/en/_messages.js
+++ b/blockly/language/en/_messages.js
@@ -177,8 +177,9 @@ Blockly.Msg.PROCEDURES_MUTATORCONTAINER_TITLE = "inputs";
 Blockly.Msg.REDO = "Redo";
 Blockly.Msg.REMOVE_COMMENT = "Remove Comment";
 Blockly.Msg.RENAME_VARIABLE = "Rename variable...";
-Blockly.Msg.DELETE_VARIABLE = "Delete variable %1";
+Blockly.Msg.DELETE_VARIABLE = "Delete variable '%1'";
 Blockly.Msg.RENAME_VARIABLE_TITLE = "Rename all '%1' variables to:";
+Blockly.Msg.DELETE_VARIABLE_CONFIRMATION = "Delete blocks containing %1 uses of the '%2' variable?";
 
 Blockly.Msg.TODAY = "Today";
 Blockly.Msg.UNDO = "Undo";

--- a/editor.js
+++ b/editor.js
@@ -734,7 +734,7 @@ function initToolbox(profileName) {
     });
 
     init(Blockly);
-    Blockly.mainWorkspace.createVariable('item');      // USE AFTER CORE IS REPLACED
+    //Blockly.mainWorkspace.createVariable('item');      // USE AFTER CORE IS REPLACED
 }
 
 function loadToolbox(xmlText) {


### PR DESCRIPTION
Removes now unnecessary functions in blocks that contained variable fields.  These functions are now handled by the core instead.

Through a better understand of the new way that blockly handles variables, I have deleted a custom function that I thought I needed, instead opting fo the built in version (variable context menu/dropdown)

Additionally, constants that provide text in prompts and menus have been added, and I'm discovering that many of the troubles I've had in updating the core stem from the fact that we are using an older _messages.js file that does not contain these constants.  This is something to note, but I still do not feel it is worthwhile to replace the messages file as ours is very customized, and tacking errors as they pop up is still probably more efficient at this point in time.