### PR TITLE
Refactor code to replace var with let where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+node_modules
 

--- a/blocklyc.js
+++ b/blocklyc.js
@@ -68,13 +68,13 @@ var graph_data = {
 };
 
 // Minimum client/launcher version supporting base64-encoding
-var minEnc64Ver = version_as_number('0.7.0');
+const minEnc64Ver = version_as_number('0.7.0');
 
 // Minimum client/launcher version supporting coded/verbose responses
-var minCodedVer = version_as_number('0.7.5');
+const minCodedVer = version_as_number('0.7.5');
 
 // Minimum client/launcher allowed for use with this system
-var minVer = version_as_number(client_min_version);
+const minVer = version_as_number(client_min_version);
 
 /**
  * Switch the visible pane when a tab is clicked.
@@ -83,7 +83,7 @@ var minVer = version_as_number(client_min_version);
  */
 function tabClick(id) {
 
-    var TABS_ = ['blocks', 'propc', 'xml'];
+    const TABS_ = ['blocks', 'propc', 'xml'];
 
     // If the XML tab was open, save and render the content.
     /* if (document.getElementById('tab_xml').className == 'active') {
@@ -109,18 +109,20 @@ function tabClick(id) {
     // Deselect all tabs and hide all panes.
     // document.getElementById('menu-save-as-propc').style.display = 'none';
 
-    for (var x in TABS_) {
+    for (let x in TABS_) {
         document.getElementById('content_' + TABS_[x]).style.display = 'none';
     }
 
     // Select the active tab.
-    var selectedTab = id.replace('tab_', '');
-    var tbxs = document.getElementsByClassName('blocklyToolboxDiv');
-    var btns = document.getElementsByClassName("btn-view-code");
+    const selectedTab = id.replace('tab_', '');
+    const tbxs = document.getElementsByClassName('blocklyToolboxDiv');
+    const btns = document.getElementsByClassName("btn-view-code");
+
     document.getElementById('btn-view-blocks').style.display = 'none';
 
-    if (document.getElementById('menu-save-as-propc'))
+    if (document.getElementById('menu-save-as-propc')) {
         document.getElementById('menu-save-as-propc').style.display = 'none';
+    }
 
     // var i was a duplicate definition.
     for (let i = 0; i < btns.length; i++) {
@@ -128,7 +130,6 @@ function tabClick(id) {
     }
 
     if (projectData['board'] !== 'propcfile') {
-
         // Reinstate keybindings from block workspace if this is not a code-only project.
         if (Blockly.codeOnlyKeybind === true) {
             Blockly.bindEvent_(document, 'keydown', null, Blockly.onKeyDown_);
@@ -136,19 +137,21 @@ function tabClick(id) {
         }
 
         if (id === 'tab_blocks') {
-            for (var i = 0; i < btns.length; i++) {
+            for (let i = 0; i < btns.length; i++) {
                 btns[i].style.display = 'inline-block';
             }
-            for (var xt = 0; xt < tbxs.length; xt++) {
+            for (let xt = 0; xt < tbxs.length; xt++) {
                 tbxs[xt].style.display = 'block';
             }
         } else {
-            for (var xt = 0; xt < tbxs.length; xt++) {
+            for (let xt = 0; xt < tbxs.length; xt++) {
                 tbxs[xt].style.display = 'none';
             }
             document.getElementById('btn-view-blocks').style.display = 'inline-block';
-            if (document.getElementById('menu-save-as-propc'))
+
+            if (document.getElementById('menu-save-as-propc')) {
                 document.getElementById('menu-save-as-propc').style.display = 'block';
+            }
         }
     } else {
 
@@ -160,15 +163,18 @@ function tabClick(id) {
             document.getElementById('prop-btn-graph').style.display = 'none';
             document.getElementById('upload-project').style.display = 'none';
         }
+
         document.getElementById('prop-btn-pretty').style.display = 'inline-block';
         document.getElementById('prop-btn-find-replace').style.display = 'inline-block';
         document.getElementById('prop-btn-undo').style.display = 'inline-block';
         document.getElementById('prop-btn-redo').style.display = 'inline-block';
+
         $('.propc-only').removeClass('hidden');
         //document.getElementById('download-project').style.display = 'none';
     }
 
     document.getElementById('content_' + selectedTab).style.display = 'block';
+
     // Show the selected pane.
     if (projectData['board'] === 'propcfile' && selectedTab === 'xml' && getURLParameter('debug')) {
         document.getElementById('btn-view-propc').style.display = 'inline-block';
@@ -185,44 +191,58 @@ function renderContent(pane) {
     // Initialize the pane.
     if (pane === 'blocks' && projectData['board'] !== 'propcfile') {
         Blockly.mainWorkspace.render();
+
     } else if (pane === 'xml') {
-        var xmlDom = null;
-        var xmlText = '';
+        let xmlDom = null;
+        let xmlText = '';
+
         if (projectData['board'] === 'propcfile') {
             xmlText = propcAsBlocksXml();
         } else {
             xmlDom = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
             xmlText = Blockly.Xml.domToPrettyText(xmlDom);
         }
+
         codeXml.setValue(xmlText);
         codeXml.getSession().setUseWrapMode(true);
         codeXml.gotoLine(0);
+
     } else if (pane === 'propc' && projectData['board'] !== 'propcfile') {
-        var raw_c = prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
+        let raw_c = prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
         codePropC.setValue(raw_c);
         codePropC.gotoLine(0);
+
     } else if (pane === 'propc') {
         if (!codePropC || codePropC.getValue() === '') {
             codePropC.setValue(atob((projectData['code'].match(/<field name="CODE">(.*)<\/field>/) || ['', ''])[1] || ''));
             codePropC.gotoLine(0);
         }
         if (codePropC.getValue() === '') {
-            var blankProjectCode = '// ------ Libraries and Definitions ------\n';
+            let blankProjectCode = '// ------ Libraries and Definitions ------\n';
             blankProjectCode += '#include "simpletools.h"\n\n\n';
             blankProjectCode += '// ------ Global Variables and Objects ------\n\n\n';
             blankProjectCode += '// ------ Main Program ------\n';
             blankProjectCode += 'int main() {\n\n\nwhile (1) {\n\n\n}}';
-            var raw_c = prettyCode(blankProjectCode);
+
+            let raw_c = prettyCode(blankProjectCode);
             codePropC.setValue(raw_c);
             codePropC.gotoLine(0);
         }   
     }
 }
 
+
+/**
+ * Pretty formatter for C code
+ *
+ * @param raw_code
+ * @returns {*}
+ */
 var prettyCode = function (raw_code) {
     if (!raw_code) {
         raw_code = codePropC.getValue();
     }
+
     raw_code = js_beautify(raw_code, {
         'brace_style': 'expand',
         'indent_size': 2
@@ -254,6 +274,11 @@ var prettyCode = function (raw_code) {
     return (raw_code);
 };
 
+
+
+/**
+ * Toggle the find-replace display style between 'block' and 'none'
+ */
 var findReplaceCode = function () {
     if (document.getElementById('find-replace').style.display === 'none') {
         document.getElementById('find-replace').style.display = 'block';
@@ -262,9 +287,18 @@ var findReplaceCode = function () {
     }
 };
 
+
+
+/**
+ * Generate a unique block ID
+ *
+ * @param nonce
+ * @returns {string}
+ */
 function generateBlockId(nonce) {
-    var blockId = btoa(nonce).replace(/=/g, '');
-    var l = blockId.length;
+    let blockId = btoa(nonce).replace(/=/g, '');
+    let l = blockId.length;
+
     if (l < 20) {
         blockId = 'zzzzzzzzzzzzzzzzzzzz'.substr(l - 20) + blockId;
     } else {
@@ -274,17 +308,28 @@ function generateBlockId(nonce) {
     return blockId;
 }
 
+
+
+/**
+ * Covert C source code into a Blockly block
+ *
+ * @returns {string}
+ */
 var propcAsBlocksXml = function () {
-    var code = '<xml xmlns="http://www.w3.org/1999/xhtml">';
+    let code = '<xml xmlns="http://www.w3.org/1999/xhtml">';
     code += '<block type="propc_file" id="' + generateBlockId(codePropC ? codePropC.getValue() : 'thequickbrownfoxjumpedoverthelazydog') + '" x="100" y="100">';
     code += '<field name="FILENAME">single.c</field>';
     code += '<field name="CODE">';
+
     if (codePropC) {
         code += btoa(codePropC.getValue().replace('/* EMPTY_PROJECT */\n', ''));
     }
+
     code += '</field></block></xml>';
     return code;
 };
+
+
 
 /**
  * Initialize Blockly.  Called on page load.
@@ -349,21 +394,39 @@ function init(blockly) {
     }
 }
 
+
+/**
+ * Set the global value for baudrate
+ *
+ * @param _baudrate
+ */
 function setBaudrate(_baudrate) {
+    // TODO: Check the supplied baudrate value to ensure that it is reasonable
+    // Set the global baudrate variable
     baudrate = _baudrate;
 }
 
+
+/**
+ * Submit a project's source code to the cloud compiler
+ *
+ * @param text
+ * @param action
+ * @param successHandler
+ */
 function cloudCompile(text, action, successHandler) {
 
     // if PropC is in edit mode, get it from the editor, otherwise render it from the blocks.
-    var propcCode = '';
+    let propcCode = '';
+
     if (codePropC.getReadOnly()) {
         propcCode = prettyCode(Blockly.propc.workspaceToCode(Blockly.mainWorkspace));
     } else {
         propcCode = codePropC.getValue();
     }
 
-    var isEmptyProject = propcCode.indexOf("EMPTY_PROJECT") > -1;
+    let isEmptyProject = propcCode.indexOf("EMPTY_PROJECT") > -1;
+
     if (isEmptyProject) {
         alert("You can't compile an empty project");
     } else {
@@ -371,12 +434,14 @@ function cloudCompile(text, action, successHandler) {
         $("#compile-console").val('Compile... ');
         $('#compile-dialog').modal('show');
 
-        var terminalNeeded = false;
+        let terminalNeeded = false;
+
         if (propcCode.indexOf("SERIAL_TERMINAL USED") > -1)
             terminalNeeded = 'term';
         else if (propcCode.indexOf("SERIAL_GRAPHING USED") > -1)
             terminalNeeded = 'graph';
 
+        // OFFLINE MODE
         if (isOffline) {
             // Compiler optimization options:
             // -O0 (None)
@@ -400,7 +465,7 @@ function cloudCompile(text, action, successHandler) {
                     document.getElementById("compile-console").scrollTop = document.getElementById("compile-console").scrollHeight;
                 }
             });
-        } else {
+        } else {  // ONLINE MODE
             $.ajax({
                 'method': 'POST',
                 'url': baseUrl + 'rest/compile/c/' + action + '?id=' + idProject,
@@ -432,12 +497,19 @@ function cloudCompile(text, action, successHandler) {
     }
 }
 
+
+/**
+ * Stub function to the cloudCompile function
+ */
 function compile() {
     cloudCompile('Compile', 'compile', function (data, terminalNeeded) {});
 }
 
+
+
 /**
- * begins loading process
+ * Begins loading process
+ *
  * @param modal_message message shown at the top of the compile/load modal.
  * @param compile_command for the cloud compiler (bin/eeprom).
  * @param load_option command for the loader (CODE/VERBOSE/CODE_VERBOSE).
@@ -445,6 +517,9 @@ function compile() {
  *
  */
 function loadInto(modal_message, compile_command, load_option, load_action) {
+
+    // TODO: the loadInto function appears to be orphaned. Verify and remove
+
     if (ports_available) {
         cloudCompile(modal_message, compile_command, function (data, terminalNeeded) {
 
@@ -537,6 +612,10 @@ function loadInto(modal_message, compile_command, load_option, load_action) {
     }
 }
 
+
+/**
+ *
+ */
 function serial_console() {
     var newTerminal = false;
 
@@ -1150,11 +1229,11 @@ function graph_new_labels() {
 }
 
 function graph_update_labels() {
-    var row = graph_temp_data.length - 1;
+    let row = graph_temp_data.length - 1;
     if (graph_temp_data[row]) {
-        var col = graph_temp_data[row].length;
-        for (var w = 2; w < col; w++) {
-            var theLabel = document.getElementById('gValue' + (w - 1).toString(10));
+        let col = graph_temp_data[row].length;
+        for (let w = 2; w < col; w++) {
+            let theLabel = document.getElementById('gValue' + (w - 1).toString(10));
             if (theLabel) {
                 theLabel.textContent = graph_temp_data[row][w];
             }


### PR DESCRIPTION
Continuing work to replace var with let in function blocks and loops where the referenced variables are only used within that scope. This is part of an effort to raise the code base to comply with the ECMAScript 2015 Standard, and reduce the possibility of a variable getting unexpectedly referenced in a larger or global scope. 