### PR TITLE
Add delays to .render() calls

### DIFF
--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -2590,11 +2590,10 @@ Blockly.Blocks.custom_code_multiple = {
                 }
             }
         }
-        try {
-            this.render();
-        } catch (err) {
-            console.log("Block Rendering Error: " + err);
-        }
+        var currBlockTimeout = this;
+        setTimeout(function() {
+            currBlockTimeout.render();
+        }, 200);
     }
 };
 

--- a/blockly/generators/propc/gpio.js
+++ b/blockly/generators/propc/gpio.js
@@ -394,11 +394,10 @@ Blockly.Blocks.base_freqout = {
             if (moveBefore) {
                 this.moveInputBefore('PIN', moveBefore);
             } else {
-                try {
-                    this.render();
-                } catch (err) {
-                    console.log("Block Rendering Error: " + err);
-                }    
+                var currBlockTimeout = this;
+                setTimeout(function() {
+                    currBlockTimeout.render();
+                }, 200);    
             }
         }
     },

--- a/blockly/generators/propc/sensors.js
+++ b/blockly/generators/propc/sensors.js
@@ -72,12 +72,10 @@ Blockly.Blocks.sensor_ping = {
             if (moveBefore) {
                 this.moveInputBefore(this.pinChoices[pinOpt], moveBefore);
             } else {
-                try {
-                    this.render();
-                } catch (err) {
-                    console.log("Block Rendering Error: " + err);
-                }
-    
+                var currBlockTimeout = this;
+                setTimeout(function() {
+                    currBlockTimeout.render();
+                }, 200);
             }
         }
     },
@@ -1600,7 +1598,10 @@ Blockly.Blocks.GPS_date_time = {
                         zone_label.setVisible(false);
                         zone_value.setVisible(false);
                     }
-                    this.sourceBlock_.render();
+                    var currBlockTimeout = this.sourceBlock_;
+                    setTimeout(function() {
+                        currBlockTimeout.render();
+                    }, 200);
                 }), "TIME_UNIT")
                 .appendField("time zone", 'ZONE_LABEL')
                 .appendField(new Blockly.FieldDropdown(timeZones), "ZONE_VALUE");


### PR DESCRIPTION
Fixes issue where some fields are not fully processed when the render() function is called, causing a full editor failure.