### PR TITLE
 Handle more possible upload variants

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -681,11 +681,15 @@ function uploadMergeCode(append) {
         }
 
         var newCode = uploadedXML;
-        newCode = newCode.substring(42, newCode.length);
+        if (newCode.indexOf('<variables>') > -1) {
+            newCode = newCode.substring(uploadedXML.indexOf('<block'), newCode.length);
+        } else {
+            newCode = newCode.substring(uploadedXML.indexOf('<variables>'), newCode.length);
+        }
         newCode = newCode.substring(0, (newCode.length - 6));
         
         // check for newer blockly XML code (contains a list of variables)
-        if (append && newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') > -1) {
+        if (newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') > -1) {
             var findVarRegExp = /type="(\w*)" id="(.{20})">(\w+)</g;
             var newBPCvars = [];
             var oldBPCvars = [];
@@ -725,7 +729,7 @@ function uploadMergeCode(append) {
             tmpv += '</variables>';
             // add everything back together
             projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + tmpv + projCode + newCode + '</xml>';
-        } else if (append && newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') === -1) {
+        } else if (newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') === -1) {
             projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + newCode + projCode + '</xml>';
         } else {
             projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + projCode + newCode + '</xml>';

--- a/editor.js
+++ b/editor.js
@@ -685,7 +685,7 @@ function uploadMergeCode(append) {
         newCode = newCode.substring(0, (newCode.length - 6));
         
         // check for newer blockly XML code (contains a list of variables)
-        if (newCode.indexOf('<variables>') > -1) {
+        if (append && newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') > -1) {
             var findVarRegExp = /type="(\w*)" id="(.{20})">(\w+)</g;
             var newBPCvars = [];
             var oldBPCvars = [];
@@ -704,17 +704,16 @@ function uploadMergeCode(append) {
                 return p;
             });
             for (var j = 0; j < oldBPCvars.length; j++) {
-                k = 0;
-                while (k < newBPCvars.length) {
+                for (var k = 0; k < newBPCvars.length; k++) {
                     // see if var is a match
                     if (newBPCvars[k][0] === oldBPCvars[j][0]) {
                         // replace old variable IDs with new ones 
                         var tmpr = newCode.split(newBPCvars[k][1]);
                         newCode = tmpr.join(oldBPCvars[j][1]);
                     } else {
+                        // add variable to list to be placed in blocklyprop xml variable defs
                         oldBPCvars.push(newBPCvars[k]);
                     }
-                    k++;
                 }
             }
 
@@ -726,6 +725,8 @@ function uploadMergeCode(append) {
             tmpv += '</variables>';
             // add everything back together
             projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + tmpv + projCode + newCode + '</xml>';
+        } else if (append && newCode.indexOf('<variables>') > -1 && projCode.indexOf('<variables>') === -1) {
+            projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + newCode + projCode + '</xml>';
         } else {
             projectData['code'] = '<xml xmlns="http://www.w3.org/1999/xhtml">' + projCode + newCode + '</xml>';
         }


### PR DESCRIPTION
Replaces while loop with a for loop to prevent lockup
Should now handle variants where the existing project has vars but the upload doesn't, vice-versa, and where both or neither have vars.