### PR TITLE
Fix graphing from ES6 change, cleanup, tag new feature experimental

### DIFF
--- a/blockly/generators/propc/base.js
+++ b/blockly/generators/propc/base.js
@@ -1614,6 +1614,16 @@ Blockly.Blocks.cog_new = {
         this.setInputsInline(true);
         this.setPreviousStatement(true, "Block");
         this.setNextStatement(true, null);
+    },
+    onchange: function(event) {
+        if (event && (event.type === Blockly.Events.CHANGE || event.type === Blockly.Events.MOVE)) {
+            var repeatWarningText = null;
+            var myRootBlock = this.getRootBlock();
+            if (myRootBlock && myRootBlock.type.indexOf('repeat') > -1 ) {
+                repeatWarningText = 'Warning: This block can only start up to 7 additional cores - using this block in a repeat loop may cause unexpected errors!';
+            }
+            this.setWarningText(repeatWarningText);
+        }
     }
 };
 

--- a/blockly/generators/propc/communicate.js
+++ b/blockly/generators/propc/communicate.js
@@ -2786,12 +2786,12 @@ Blockly.propc.oled_initialize = function () {
                 }    
             }
 
-            if (cogStartBlock) {
+            if (cogStartBlock && inDemo) {  // ONLY RUN IN DEMO - keep this experimental for now.
                 Blockly.propc.cog_setups_[this.myType] = [cogStartBlock, this.myType + ' = ' + 
                         devType + '_init(' + pin.join(', ') + devWidthHeight + ');'];
             } else {
                 Blockly.propc.setups_[this.myType] = this.myType + ' = ' + devType + '_init(' + pin.join(', ') + devWidthHeight + ');';
-            }
+            }         
         }
     }
     return '';

--- a/blocklyc.js
+++ b/blocklyc.js
@@ -87,11 +87,6 @@ var graph_temp_data = new Array;
 var graph_data_ready = false;
 
 
-// The IDE reports this as an unused variable
-// TODO: Verify that the 'graph_connection_string' variable is no longer required.
-// var graph_connection_string = '';
-
-
 /**
  * Graph data series start timestamp
  *
@@ -170,15 +165,6 @@ var graph_labels = null;
  * @type {any[]}
  */
 var graph_csv_data = new Array;
-
-
-// The IDE sees this as an unused variable
-// TODO: Verify that the 'console_header_arrived' variable is no longer required.
-var console_header_arrived = false;
-
-// The IDE sees this as an unused variable
-// TODO: Verify that the 'console_header' variable is no longer required.
-var console_header = null;
 
 
 /**
@@ -1275,6 +1261,7 @@ function graph_new_data(stream) {
         $("#graph-conn-info").html(stream);
 
     } else {
+        var ts = 0;
         for (k = 0; k < stream.length; k++) {
             if (stream[k] === '\n')
                 stream[k] = '\r';
@@ -1282,7 +1269,7 @@ function graph_new_data(stream) {
                 if (!graph_paused) {
                     graph_temp_data.push(graph_temp_string.split(','));
                     var row = graph_temp_data.length - 1;
-                    let ts = Number(graph_temp_data[row][0]) || 0;
+                    ts = Number(graph_temp_data[row][0]) || 0;
 
                     // convert to seconds:
                     // Uses Propeller system clock (CNT) left shifted by 16.
@@ -1338,13 +1325,12 @@ function graph_new_data(stream) {
                     if (graph_csv_data.length > 15000) {
                         graph_csv_data.shift();
                     }
-                    //$('.ct_line').css('stroke-width','1px'); // TODO: verify if this is even necessary
                 }
 
                 graph_temp_string = '';
             } else {
                 if (!graph_data_ready) {            // wait for a full set of data to
-                    if (stream[k] === '\r') {      // come in before graphing, ends up
+                    if (stream[k] === '\r') {       // come in before graphing, ends up
                         graph_data_ready = true;    // tossing the first point but prevents
                     }                               // garbage from mucking up the graph.
                 } else {
@@ -1432,17 +1418,12 @@ function downloadGraph() {
             svgxml = svgxml.replace(pattern, '');
 
             // TODO: Lint is complaining about the search values. Should they be enclosed in quotes?
-//            svgxml = svgxml.replace(/foreignObject/g, 'text');
-//            svgxml = svgxml.replace(/([<|</])a[0-9]+:/g, '$1');
-//            svgxml = svgxml.replace(/xmlns: /g, '');
-//            svgxml = svgxml.replace(/span/g, 'tspan');
-//            svgxml = svgxml.replace(/x="10" /g, 'x="40" ');
-
-            svgxml = svgxml.replace('/foreignObject/g', 'text');
-            svgxml = svgxml.replace('/([<|</])a[0-9]+:/g', '$1');
-            svgxml = svgxml.replace('/xmlns: /g', '');
-            svgxml = svgxml.replace('/span/g', 'tspan');
-            svgxml = svgxml.replace('/x="10" /g', 'x="40" ');
+            // No: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+            svgxml = svgxml.replace(/foreignObject/g, 'text');
+            svgxml = svgxml.replace(/([<|</])a[0-9]+:/g, '$1');
+            svgxml = svgxml.replace(/xmlns: /g, '');
+            svgxml = svgxml.replace(/span/g, 'tspan');
+            svgxml = svgxml.replace(/x="10" /g, 'x="40" ');
 
             svgxml = svgxml.substring(svgxml.indexOf('<svg'), svgxml.length - 6);
             var foundY = svgxml.indexOf(findY);


### PR DESCRIPTION
Please be careful with lint suggestions to change "var" to "let" - let is scoped more narrowly (inside the set of braces it's declared within) and var is elevated to the function, and is therefore available anywhere within the function.  I agree that these changes need to be made, but we may need to test any functionalities receiving updates more thoroughly.

Also, just FYI - javascript strings are enclosed with "" or '', with single quotes preferred (because it's then easier to generate code containing double-quotes).  Regular expressions are enclosed in / / immediately followed by a modifier like "g" or "i".

More info here: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)