### PR TITLE
1.2.1 - Enable missing block families

### DIFF
--- a/blockly/generators/propcToolbox.js
+++ b/blockly/generators/propcToolbox.js
@@ -637,7 +637,7 @@ xmlToolbox += '                </value>';
 xmlToolbox += '            </block>';
 xmlToolbox += '        </category>';
 
-xmlToolbox += '        <category key="category_communicate_epaper" exclude="heb,heb-wx," experimental="true">';
+xmlToolbox += '        <category key="category_communicate_epaper" exclude="heb,heb-wx,">';
 xmlToolbox += '            <block type="epaper_initialize"></block>';
 xmlToolbox += '            <block type="oled_font_loader"></block>';
 xmlToolbox += '            <block type="epaper_update"></block>';
@@ -1092,7 +1092,7 @@ xmlToolbox += '        <category key="category_sensor-input_4x4-keypad" >';
 xmlToolbox += '            <block type="keypad_initialize"></block>';
 xmlToolbox += '            <block type="keypad_read"></block>';
 xmlToolbox += '        </category>';
-xmlToolbox += '        <category key="category_sensor-input_BME680" experimental="true">';
+xmlToolbox += '        <category key="category_sensor-input_BME680">';
 xmlToolbox += '            <block type="bme680_init"></block>';
 xmlToolbox += '            <block type="bme680_read"></block>';
 xmlToolbox += '            <block type="bme680_get_value"></block>';

--- a/blockly/generators/propcToolbox.js
+++ b/blockly/generators/propcToolbox.js
@@ -1,9 +1,43 @@
-/* 
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/*
+ * Copyright (c) 2019 Parallax Inc.
+ *
+ * qPortions Copyright 2014 Michel Lampo, Vale Tolpegin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
+
+/**
+ * Create a string representation of an XML array that defines the menu system used
+ * in the editor page.
+ *
+ * @type {string}
+ *
+ * @description
+ *
+ * Block definitions may contain the 'experimental=true' attribute. This designates
+ * the menu item as 'not ready for production' and will be excluded from systems that
+ * are configured to disbale experimental code. See the configuration option 'experimental'
+ * for additional details.
+ *
+ * Note that the code below currently detects that the attribute
+ * exists and DOES NOT evaluate the value of the attribute.
+ */
 
 var xmlToolbox = '';
 xmlToolbox += '<xml id="toolbox">';
@@ -1704,31 +1738,54 @@ function filterToolbox(profileName) {
         });
     }
 
-    // Convert the string to an XML object
+    // Convert the xmlToolBox string to an XML object
     parser = new DOMParser();
     xmlDoc = parser.parseFromString(xmlToolbox, "text/xml");
 
     // Loop through the specified tags and filter based on their attributes
     tagSearch = ['category', 'sep', 'block'];
+
+    // Toolbnox entries to be removed from the menu
     var toRemove = [];
 
+    //Scan the toolBox XML document for each search tag
     for (var j = 0; j < tagSearch.length; j++) {
 
         var xmlElem = xmlDoc.getElementsByTagName(tagSearch[j]);
 
         for (var t = 0; t < xmlElem.length; t++) {
 
+            // Get the current XML element
             var toolboxEntry = xmlElem[t];
 
+            // The include attribute defines specific supported board types
             var include = toolboxEntry.getAttribute('include');
+
+            // The exclude attribute defines board types that are specifically excluded
+            // from the block under consideration
             var exclude = toolboxEntry.getAttribute('exclude');
+
+            // The experimental attribute is used to decalre that the current menu item
+            // is considered experimental
             var experimental = toolboxEntry.getAttribute('experimental');
-            
+
+            // Place this entry on the removal list if the include attribute is
+            // defined and is does not match the board type that is currently
+            // defined for the project.
             if (include && include.indexOf(profileName + ',') === -1) {
                 toRemove.push(toolboxEntry);
-            } else if (exclude && exclude.indexOf(profileName + ',') > -1) {
+            }
+
+            // Place this entry on the removal list if the exclude attribute is
+            // defined and does match the board type that is currently defined
+            // for the project.
+            else if (exclude && exclude.indexOf(profileName + ',') > -1) {
                 toRemove.push(toolboxEntry);
-            } else if (experimental && inDemo !== 'demo') {
+            }
+
+            // if the XML element has an experimental attribute and the current
+            // environment is not the Demo system, exclude the menu entry
+            else if (experimental && inDemo !== 'demo') {
                 // Remove toolbox categories that are experimental if not in demo
                 toRemove.push(toolboxEntry);
             }


### PR DESCRIPTION
The BME-680 and e-Paper block groups were tagged in the menu system as experimental and were excluded when running on the production system.

Removed the 'experimental' designation on the menu blocks to enable the features on the production system.