### PR TITLE
Add check for non-null projectData before acting on the object.

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -870,6 +870,11 @@ window.onbeforeunload = function () {
  * TODO: We might get here if we failed to load a new project.
  */
 var checkLeave = function () {
+    // Return if there is no project data
+    if (!projectData) {
+        return false;
+    }
+
     var currentXml = '';
     var savedXml = projectData['code'];
     if (ignoreSaveCheck) {


### PR DESCRIPTION
Fixes issue parallaxinc#144.
Code was referencing attributes of a null global projectData object without checking the state of the object. This update evaluates the global projectData variable before attempting to use it.