### PR TITLE
Solo 13 force window resize on tab load

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -460,6 +460,14 @@ var showNewProjectModal = function(openModal) {
             window.localStorage.setItem('localProject', JSON.stringify(pd));
             window.location = 'blocklyc.html';
         }
+        // Force the toolbox to render correctly
+        setTimeout(function () {
+            // find the height of just the blockly workspace by subtracting the height of the navigation bar
+            let navHeight = $(window).height() - $('tr').first().outerHeight();
+            if (navHeight) {
+                $('#content_blocks, #content, .injectionDiv').height(navHeight);
+            }
+        }, 100); // use a short delay to ensure the DOM is fully ready (TODO: may not be necessary)
     });
 }
 


### PR DESCRIPTION
Forces the blockly toolbox's height to be recalculated shortly after the new/edit project modal is closed by clicking the "continue" button.

Addresses [blocklyprop-solo/issue-13](https://github.com/parallaxinc/solo/issues/13)