### PR TITLE
Solo 16 adjust ui elements

### DIFF
--- a/blockly/language/en/_messages.js
+++ b/blockly/language/en/_messages.js
@@ -786,6 +786,7 @@ page_text_label['confirm_request_title'] = "Email confirm request";
 page_text_label['confirm_requested'] = "Please check your email";
 page_text_label['editor_button_append'] = "Append";
 page_text_label['editor_button_cancel'] = "Cancel";
+page_text_label['editor_button_open'] = "Open";
 page_text_label['editor_button_close'] = "Close";
 page_text_label['editor_button_continue'] = "Continue";
 page_text_label['editor_button_replace'] = "Replace";
@@ -815,6 +816,8 @@ page_text_label['editor_replace_label'] = "Replace: ";
 page_text_label['editor_newproject_c'] = "Propeller C";
 page_text_label['editor_newproject_spin'] = "Scribbler Robot";
 page_text_label['editor_newproject_title'] = "New project";
+page_text_label['editor_open'] = "Open blocks file"
+page_text_label['editor_import'] = "Import blocks file"
 page_text_label['editor_project'] = "Project";
 page_text_label['editor_projects_title'] = "Projects";
 page_text_label['editor_run_compile'] = "Compile";
@@ -1079,33 +1082,6 @@ var tooltip_text = [
     ['project-form-edit-private', 'Hide project from other users']
 ];
 
-// Insert the text strings (internationalization) once the page has loaded
-$(document).ready(function () {
-    
-    // insert into <span> tags
-    $(".keyed-lang-string").each(function () {
-        var span_tag = $(this);
-        
-        // Set the text of the label spans
-        var pageLabel = span_tag.attr('data-key');
-        if (pageLabel) {
-            if (span_tag.is('a')) {
-                span_tag.attr('href', page_text_label[pageLabel]);
-            } else if (span_tag.is('input')) {
-                span_tag.attr('value', page_text_label[pageLabel]);
-            } else {
-                span_tag.html(page_text_label[pageLabel]);
-            }
-        }
-    });
-    
-    // insert into button/link tooltips
-    for (var i = 0; i < tooltip_text.length; i++) {
-        if (tooltip_text[i] && document.getElementById(tooltip_text[i][0])) {
-            $('#' + tooltip_text[i][0]).attr('title', tooltip_text[i][1]);
-        }
-    }
-});
 
 
 // If online, return the full help URL, if offline, open a modal

--- a/editor.js
+++ b/editor.js
@@ -537,13 +537,13 @@ function resetToolBoxSizing(d) {
             // find the height of just the blockly workspace by subtracting the height of the navigation bar
             let navHeight = $(window).height() - $('tr').first().outerHeight();
             if (navHeight) {
-                $('#content_blocks, #content, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+                $('#content_blocks, #content, .blocklySvg, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
             }
         }, d);
     } else {
         let navHeight = $(window).height() - $('tr').first().outerHeight();
         if (navHeight) {
-            $('#content_blocks, #content, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+            $('#content_blocks, #content, .blocklySvg, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
         }
     }
 }

--- a/editor.js
+++ b/editor.js
@@ -537,14 +537,18 @@ function resetToolBoxSizing(d) {
             // find the height of just the blockly workspace by subtracting the height of the navigation bar
             let navHeight = $(window).height() - $('tr').first().outerHeight();
             if (navHeight) {
-                $('#content_blocks, #content, .blocklySvg, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+                $('#content_blocks, #content, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+                $('.blocklySvg').attr('height', navHeight);
             }
+            //Blockly.mainWorkspace.getCanvas().resize();
         }, d);
     } else {
         let navHeight = $(window).height() - $('tr').first().outerHeight();
         if (navHeight) {
-            $('#content_blocks, #content, .blocklySvg, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+            $('#content_blocks, #content, .injectionDiv, .blocklyToolboxDiv').height(navHeight);
+            $('.blocklySvg').attr('height', navHeight);
         }
+        //Blockly.mainWorkspace.getCanvas().resize();
     }
 }
 


### PR DESCRIPTION
Makes UI adjustments when the application is in Offline mode.
- Adds text strings to internationalization file
- Moves function that populates editor HTML page with text to the editor.js file to ensure that it happens during the first part of the DOM load.
- creates a re-sizer function to handle CSS bug that inadvertently hides the toolbox/canvas when the window is certain sizes that is called whenever the window is resized or when a project is loaded or opened.  This should also when when the application href/location changes (back button, refresh, etc.)
- Adds specific class for blockly toolbox into re-sizer function
- Makes test in open/import modal more appropriate for an offline app when in offline mode
- Cancel button when opening a file now correctly navigates back to splash page
- Open button now starts off disabled until a valid project is loaded

Addresses [solo 10, 13, 16, and 17](https://github.com/parallaxinc/solo/issues)
