### PR TITLE
Add copy of the nav-logo element to display logo on the home page.

### DIFF
--- a/style.css
+++ b/style.css
@@ -215,3 +215,17 @@ div#project div.wizard-container {
     border-color: grey;
     text-decoration: none;
 }
+
+#nav-logo {
+    background-image: url('images/logo_small.png');
+    background-repeat: no-repeat;
+    background-size: 50px 50px;
+    padding-left: 55px;
+    margin-left: 5px;
+    margin-top: 5px;
+    height: 50px;
+    font-size: 22px;
+    line-height: 25px;
+    display: inline;
+    float: left;
+}


### PR DESCRIPTION
Addresses issue parallaxinc/BlocklyProp-cdn#161.

Add a css element in the style.css to support a background logo on the the Solo home page.