### PR TITLE
Solo 34 prop c editor behind demo fuse

### DIFF
--- a/blocklyc.js
+++ b/blocklyc.js
@@ -291,7 +291,7 @@ function renderContent(id) {
             $('#btn-view-blocks').css('display', 'none');
         } else {
             $('#btn-view-xml').css('display', 'none');
-            $('#btn-view-blocks').css('display', 'inline-block');    
+            $('#btn-view-blocks').css('display', (isPropcOnlyProject ? 'none' : 'inline-block'));   
         }
         $('#btn-view-propc').css('display', 'none');
         if (!isPropcOnlyProject) {
@@ -313,7 +313,7 @@ function renderContent(id) {
                 let raw_c = prettyCode(blankProjectCode);
                 codePropC.setValue(raw_c);
                 codePropC.gotoLine(0);
-            }   
+            } 
         }
         break;
       case 'xml':

--- a/editor.js
+++ b/editor.js
@@ -478,12 +478,19 @@ var showNewProjectModal = function(openModal) {
     // defined in propc.js in the 'profile' object
     // (except 'default', which is where the current project's type is stored)
     for(var boardTypes in profile) {
-        if (boardTypes !== 'default') {
+        if (boardTypes !== 'default' && boardTypes !== 'propcfile') {
             $("#new-project-board-type")
                     .append($('<option />')
                     .val(boardTypes)
                     .text(profile[boardTypes].description));
         }
+    }
+    // TODO: only show the code-only project option if in Demo/experimental
+    if (inDemo) {
+        $("#new-project-board-type")
+        .append($('<option />')
+        .val('propcfile')
+        .text(profile['propcfile'].description));
     }
 
     // when the user clicks the 'Continue' button, validate the form


### PR DESCRIPTION
Ensures that when the inDemo fuse is not in use, all access to the prop c editor is removed.