### PR TITLE
Make help/reference link dynamic by board type

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -594,6 +594,14 @@ var setupWorkspace = function (data) {
 
         // Create UI block content from project details
         renderContent('blocks');
+
+        // Set the help link to the ab-blocks or s3 reference
+        // TODO: modify blocklyc.html/jsp and use an id or class selector
+        if (projectData.board === 's3') {
+            $('[href="public/help"]').attr('href', 'https://learn.parallax.com/s3-blocks');
+        } else {
+            $('[href="public/help"]').attr('href', 'https://learn.parallax.com/ab-blocks');
+        }
     } else {
         // No, init the blockly interface
         init(Blockly);
@@ -607,6 +615,10 @@ var setupWorkspace = function (data) {
         
         // Create UI block content from project details
         renderContent('propc');
+
+        // Set the help link to the prop-c reference
+        // TODO: modify blocklyc.html/jsp and use an id or class selector
+        $('[href="public/help"]').attr('href', 'https://learn.parallax.com/support/C/propeller-c-reference');
     }
 
 


### PR DESCRIPTION
Addresses [solo-48](https://github.com/parallaxinc/solo/issues/48)

Replaces URL with one that is appropriate for the board/device type.