### PR TITLE
Solo 67 replace all performance now with get timestamp

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -181,15 +181,15 @@ const clearNewProjectModal = () => {
  */
 const timestampSaveTime = (mins, resetTimer) => {
     // Mark the time when the project was opened, add 20 minutes to it.
-    const d_save = new Date();
+    const d_save = getTimestamp();
 
     // If the proposed delay is less than the delay that's already in
     // process, don't update the delay to a new shorter time.
-    if (d_save.getTime() + (mins * 60000) > last_saved_timestamp) {
-        last_saved_timestamp = d_save.getTime() + (mins * 60000);
+    if (d_save + (mins * 60000) > last_saved_timestamp) {
+        last_saved_timestamp = d_save + (mins * 60000);
 
         if (resetTimer) {
-            last_saved_time = d_save.getTime();
+            last_saved_time = d_save;
         }
     }
 };
@@ -210,8 +210,7 @@ function getTimestamp() {
  *
  */
 const checkLastSavedTime = function () {
-    const d_now = new Date();
-    const t_now = d_now.getTime();
+    const t_now = getTimestamp();
     const s_save = Math.round((d_now.getTime() - last_saved_time) / 60000);
 
     $('#save-check-warning-time').html(s_save.toString(10));
@@ -678,7 +677,7 @@ $(document).ready( () => {
             var pd = JSON.parse(window.localStorage.getItem('localProject'));
             // load the project from the browser store
             // check to make sure the project in localStorage is less than 15 seconds old.
-            if (pd.timestamp && ((performance.now() - pd.timestamp) < 15000)) {
+            if (pd.timestamp && ((getTimestamp() - pd.timestamp) < 15000)) {
                 setupWorkspace(pd, function () {
                     window.localStorage.removeItem('localProject');
                 });
@@ -830,7 +829,7 @@ function showNewProjectModal(openModal) {
                 'type': "PROPC",
                 'user': "offline",
                 'yours': true,
-                'timestamp': performance.now(),
+                'timestamp': getTimestamp(),
             }
 
             // then load the toolbox using the projectData
@@ -1192,7 +1191,7 @@ function saveProjectAs (requestor) {
             'type': "PROPC",
             'user': "offline",
             'yours': true,
-            'timestamp': performance.now(),
+            'timestamp': getTimestamp(),
         }
 
         window.localStorage.setItem('localProject', JSON.stringify(pd));
@@ -1388,7 +1387,7 @@ function downloadCode() {
         // this will allow the project to be reloaded.
         if (isOffline) {
             // make the projecData object reflect the current workspace and save it into localStorage
-            projectData.timestamp = performance.now();
+            projectData.timestamp = getTimestamp();
             projectData.code = EmptyProjectCodeHeader + projXMLcode + '</xml>';
             window.localStorage.setItem('localProject', JSON.stringify(projectData));
 
@@ -1498,7 +1497,7 @@ function uploadHandler(files) {
             	    'type': "PROPC",
             	    'user': "offline",
             	    'yours': true,
-                    'timestamp': performance.now(),
+                    'timestamp': getTimestamp(),
 		        }
 
                 projectData = pd;
@@ -1564,7 +1563,7 @@ function uploadMergeCode(append) {
         // the offline app, load the selected project
         if (!append && getURLParameter('openFile') === 'true') {
             // Set a timestamp to note when the project was saved into localStorage
-            projectData.timestamp = performance.now();
+            projectData.timestamp = getTimestamp();
             window.localStorage.setItem('localProject', JSON.stringify(projectData));
             window.location = 'blocklyc.html';
         }


### PR DESCRIPTION
Addresses [solo-67](https://github.com/parallaxinc/solo/issues/67)

Performance.now() was used throughout the file because there were multiple points where object could be updated before saving/closing/etc.  Performance.now() does not return the save value as getTime(), so the subtraction used to determine the age of the localStorage instance was not calculating correctly, allowing the project to persist.