### PR TITLE
Issue solo 63 save project before new project modal

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -414,9 +414,20 @@ function initEventHandlers() {
     });
 
     // Load a new project
-    $('#new-project-menu-item').on('click', function () {
+    $('#new-project-menu-item').on('click', () => {
+        // If the current project has been modified, give the user
+        // an opportunity to abort the new project process.
+        if (checkLeave()) {
+            const message =
+                'The current project has been modified. Click OK to\n' +
+                'discard the current changes and create a new project.';
+            if (! confirm(message)) {
+                return;
+            }
+        }
         clearNewProjectModal();
-        showNewProjectModal('open');
+        showNewProjectModal({keyboard: false, backdrop: 'static'});
+
     });// window.location = 'blocklyc.html?newProject=true'  });
 
     $('#btn-graph-play').on('click',        function () {  graph_play();  });
@@ -519,6 +530,28 @@ function initCdnImageUrls() {
 
 
 /**
+ * Initialize the UI elements that display the users logged-in state
+ * in the production BlocklyProp system. These elements do not exist
+ * in the BlocklyProp Solo or BlocklyProp Local systems.
+ */
+function initLoginUiElement() {
+    // Offline has no concept of authentication
+    if (isOffline) {
+        return;
+    }
+
+    if (user_authenticated) {
+        $('.auth-true').css('display', $(this).attr('data-displayas'));
+        $('.auth-false').css('display', 'none');
+    } else {
+        $('.auth-false').css('display', $(this).attr('data-displayas'));
+        $('.auth-true').css('display', 'none');
+    }
+}
+
+
+
+/**
  * Execute this code as soon as the DOM becomes ready.
  */
 $(document).ready( () => {
@@ -587,14 +620,9 @@ $(document).ready( () => {
     // Reset the upload/import modal to its default state when closed
     $('#upload-dialog').on('hidden.bs.modal', resetUploadImportModalDialog());
 
+    // Set up login/guest user UI elements
+    initLoginUiElement();
 
-    if (user_authenticated) {
-        $('.auth-true').css('display', $(this).attr('data-displayas'));
-        $('.auth-false').css('display', 'none');
-    } else {
-        $('.auth-false').css('display', $(this).attr('data-displayas'));
-        $('.auth-true').css('display', 'none');
-    }
 
     $('.url-prefix').attr('href', function (idx, cur) {
         return baseUrl + cur;


### PR DESCRIPTION
Addresses parallaxinc/solo#63.
This update will display an alert when the user selects New Project from the hamburger menu AND the current project has been modified but not persisted to storage. The alert provides the user with the option to cancel the New Project process - to ostensibly save their work on the current project. If the user elects to proceed, the current project will be overwritten when the new project is created.

Also attached to this patch is code to update the user authentication status only if the user is on the BlocklyProp site.