### PR TITLE
Correct minor errors in code

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -425,7 +425,7 @@ function initEventHandlers() {
             }
         }
         clearNewProjectModal();
-        showNewProjectModal({keyboard: false, backdrop: 'static'});
+        showNewProjectModal('open');
 
     });// window.location = 'blocklyc.html?newProject=true'  });
 

--- a/editor.js
+++ b/editor.js
@@ -211,7 +211,7 @@ function getTimestamp() {
  */
 const checkLastSavedTime = function () {
     const t_now = getTimestamp();
-    const s_save = Math.round((d_now.getTime() - last_saved_time) / 60000);
+    const s_save = Math.round((t_now - last_saved_time) / 60000);
 
     $('#save-check-warning-time').html(s_save.toString(10));
 


### PR DESCRIPTION
Replace d_now reference to unknown variable with reference to t_now which contains the current timestamp.

Rewind a change in a call to showNewProjectModal that incorrectly passed in an object when the function was expecting a string.
