### PR TITLE
Issue 218 null project name

### DIFF
--- a/project.js
+++ b/project.js
@@ -367,28 +367,24 @@ function getSomeProjects(listOffset) {
  */
 function processProjectData(projectId, listOffset, callbackTrigger) {
     $.get(baseUrl + 'rest/shared/project/editor/' + projectId, function () {}).done(function (ddd) {
-        var svgBase = '<svg blocklyprop="blocklypropproject" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="240" width="480" style="font-family:Arial, Helvetica, sans-serif;font-size:20px;"><rect width="480" height="110" style="fill:#eee;stroke:none;" /><text x="100" y="25" fill="#339">NOTE: To convert this file to an SVG</text><text x="100" y="50" fill="#339">image that shows an image of the</text><text x="100" y="75" fill="#339">blocks, open the file in BlocklyProp</text><text x="100" y="100" fill="#339">and resave it as a new file.</text><image height="80" width="80" x="10" y="15" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAApCAMAAAButatJAAAC+lBMVEUAAAAAAAoLS3YGP2QHQGQSZqAGPmEVcLAGPWAYdbkLTHYLTXcYcrUVa6gSZZ8WbKoAGC8XdbgSY5wAFBoAEyEAGCIWbawVcbIGPmIPS3YJRWsONVAAFB4AAAASZqIWaKETaaUNUH0KRm0MS3YKQWYGOVoEOFYDM1AUQmIBIzgAHCsTaKMVcrMOVYUQXI8PXpMMTHYQX5UQU4EPYJgLSXQMTHYMR24KRm4IQmcOVYcRVIQSRGYHP2MIQ2YEMUgAITQAMEj/v4D///8Xdbj09PX6+vumrLUXcLG0v8aQnq8RT3iZoqwSUn0bc7MscKkXbKkfbaj5+voadLUrcKoYaKGlssEbdbcYc7QXcrMucKcXaaQXZZwWYpcUWYkUVoIXdLYYa6aClKQqbKIma6EXZ58YXo8kW4gUWIYcVYERUHobTnT8/f2is8Iic7AbcrAlcq8bb68Wb68rcqwncawqb6eClqYmbKQfa6QWY5oeWIMVV4MiV4EWVIATU38fVX4XTHIRSnCzv8cdc7IecbAYcK0nb6gebKYubaEsap8bZ58mYZIfX48WXY8VW4wfWYUpWYQTVIAYVH8dU30PP2O2wMohc7GSoLCboqwrZ5kfYZMMWY8nX44YXI4fXY0bW4wYWoscW4kgWYgTVocfUXocUHgST3UQTHQWRmkWQ2X29/insb4jcK0YbqyNnKkcaaIaY5gaX5MlXYshXIoNVIgcWYYYWIYjWIUZV4QqV3sWSm8YSG4TSGwXSGsUQGHDyc+5wcq1v8atuMQWdbqcqLUeb6wbbKgQaagkbacub6SGlaEeaKAfZp0NYZwcZZsZYJMWX5EYW5E0Zo8LV4sYWogWVIQVTnsQRGsGOVwLN1jw8fLNz9S2u8KrtMGnrLYbbqsNY6F9jp4XZZ4LXpgjZJcpY5UVYJQvZI0kX40pW4sbVYUgU3sXUnsHPmMMOl7s7e6zvcWmr7mWprWlqrMQcLKdpbBuhpsrZ5smZ5sRXZAvZIw9YoULUoQeSW8bRmvqNATaAAAAQnRSTlMAA5Wciv6e84z8trb99P7zBv3zGRUP+POWkIhMCQH99/DPsrCog3djX1Eg/Pvz8vDt7Obc2MXFurq5tJ2Oejk2NQRMzor9AAAEo0lEQVQ4y23UB1QScRzAcaisbJqjvffeewcVRSyBZDhABGQkDkhREMi9TS3T3LkzZ25tamrOzFLbe++93+t/x1n28svv3bt37/Pecfe/OxQKZTJ3XD/Q+Pko1CSTTf3+b9wEoMzGr5hsYGAw2bjfZtOt45cZjNBn8DfjAYBNWGJhgbXAnrcwXjduvbGMwZAxGUQGh0gFB/UzBmJjvWg0hvwwkURzsqM48SgnAigneBQKz9eJRHQgyak06iCI9T8sJxEdHRxoCidfio+dGxkaP1dXHo7k7SsnUUkIo9JcnIOC8uPiCp4KL4UL48NTwCSEFxY8dctRyL1Yh/UMS8S1v7u5b+9eaI4jA+1Ht9d5yxheVIRh7+y+tr2PXh96XMdkcjgIs7j/BtNn2ee+1TFlCKO6JO7CYE7nRu+O3t2r6HNSzLVzj/NIOXrm4JJ0FoO5eEWYGFYs0jx/HpmqjhRp3FXuuVJM9unvfiQ9I7KKdwEmKhSUupdpIiNSU9WpojJVWHx5rjlme02Cr54xvY8Ctv+kIKSjxCNC7fmC4Bmh9ijriI8XHceYH7okGwmxgUwcxGxPCkKtPTw9xWI8XiwmHLSxDw2xtoUYTs9wevYjBCgCHp+ekZGOxwNnHXryLmAhuJGDYcY7dgCwq+4eqWl4rU5XXaWrTMdL1B4ayU2M+ZlSH4S5XgHs4lWVJk2SXqGryszUVevwEkLkz+hsTHZNym2EBYgAuxtV2RkV9fJVV1d3d1f3q5dRnVkfd4Bzhj90Gw4zH8ox8N+u7zmy58iRPT2B/Rvm4JThVo1+euZ84jJgUvMd/2YuxUjPlD+is8m9WF9JT5d/VfL/MFfoSq+/v3Vr57/llls/iQ38cgFh8JXadkq0lZlZWaeiwO9UVlbmrwxJR1FwUGAMwnC8Z/r7FpEm0VZU6zKrqqortZI0G1VyURxgfsgNqYeu1JZQbB/5QqzVZlRUZGjTxWnqEvfE1tgWNzsKYL3WNMTa3saTIMaD4DW1DmmzslQuXYRDnhAm/IRcbgsF7qAnAXQQUqFtj5SWy+fNW7l4FsQYOaEQO1YgSCm2F9nYREaoIzzs3ZMFwfmWgatNJppsMYXfU1byWcCexQYLS5NUZSKNpkRVElYqLIjLp0+ZaTYRDRDEXJIglvQg9olQkJIcFqZKCksuKirMD2piT+k/0QhhWPDKAJb4oCUouLUwQSAEE9waF9vysIk7fCAaPQlh5+9DrJlL599TKq3glMp7fDqbSx493WiSkREaZtjmt9Idn+6QuWw6n28Jx+fTwZqTfXymmZjNGTsBZkTn9hs1CbUXyG557EY6vSmQH0hn53HJFB+ct/HgDc1jNsKM5Pgh2ErW4E8JCOB+dmuMiWHH5HEDKPX+ChmLyPW3gG/vWI6j43nw4ZIrFPW8265+dnYB4MPlzKtV5LCoNC+sCxFmcxa40DgkGpFF825QOPn71vq7gq1Tg9yb5egFjQPMzNaONhxlaDhqFIdDZTCG9WQIHdRvxgxGgUxnzxg6dOiQVcOxWOzoaUOQwJGemTEXBYc2QqPRpjOnLpw6fT76/4y2oXplNnvNLFNU3/0G7BsqpMnuQ18AAAAASUVORK5CYII="></image>';
+        // Flag invalid project data elements
+        var validProject = false;
+
         var project_filename;
         var projXMLcode;
+        var svgBase = '<svg blocklyprop="blocklypropproject" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="240" width="480" style="font-family:Arial, Helvetica, sans-serif;font-size:20px;"><rect width="480" height="110" style="fill:#eee;stroke:none;" /><text x="100" y="25" fill="#339">NOTE: To convert this file to an SVG</text><text x="100" y="50" fill="#339">image that shows an image of the</text><text x="100" y="75" fill="#339">blocks, open the file in BlocklyProp</text><text x="100" y="100" fill="#339">and resave it as a new file.</text><image height="80" width="80" x="10" y="15" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAApCAMAAAButatJAAAC+lBMVEUAAAAAAAoLS3YGP2QHQGQSZqAGPmEVcLAGPWAYdbkLTHYLTXcYcrUVa6gSZZ8WbKoAGC8XdbgSY5wAFBoAEyEAGCIWbawVcbIGPmIPS3YJRWsONVAAFB4AAAASZqIWaKETaaUNUH0KRm0MS3YKQWYGOVoEOFYDM1AUQmIBIzgAHCsTaKMVcrMOVYUQXI8PXpMMTHYQX5UQU4EPYJgLSXQMTHYMR24KRm4IQmcOVYcRVIQSRGYHP2MIQ2YEMUgAITQAMEj/v4D///8Xdbj09PX6+vumrLUXcLG0v8aQnq8RT3iZoqwSUn0bc7MscKkXbKkfbaj5+voadLUrcKoYaKGlssEbdbcYc7QXcrMucKcXaaQXZZwWYpcUWYkUVoIXdLYYa6aClKQqbKIma6EXZ58YXo8kW4gUWIYcVYERUHobTnT8/f2is8Iic7AbcrAlcq8bb68Wb68rcqwncawqb6eClqYmbKQfa6QWY5oeWIMVV4MiV4EWVIATU38fVX4XTHIRSnCzv8cdc7IecbAYcK0nb6gebKYubaEsap8bZ58mYZIfX48WXY8VW4wfWYUpWYQTVIAYVH8dU30PP2O2wMohc7GSoLCboqwrZ5kfYZMMWY8nX44YXI4fXY0bW4wYWoscW4kgWYgTVocfUXocUHgST3UQTHQWRmkWQ2X29/insb4jcK0YbqyNnKkcaaIaY5gaX5MlXYshXIoNVIgcWYYYWIYjWIUZV4QqV3sWSm8YSG4TSGwXSGsUQGHDyc+5wcq1v8atuMQWdbqcqLUeb6wbbKgQaagkbacub6SGlaEeaKAfZp0NYZwcZZsZYJMWX5EYW5E0Zo8LV4sYWogWVIQVTnsQRGsGOVwLN1jw8fLNz9S2u8KrtMGnrLYbbqsNY6F9jp4XZZ4LXpgjZJcpY5UVYJQvZI0kX40pW4sbVYUgU3sXUnsHPmMMOl7s7e6zvcWmr7mWprWlqrMQcLKdpbBuhpsrZ5smZ5sRXZAvZIw9YoULUoQeSW8bRmvqNATaAAAAQnRSTlMAA5Wciv6e84z8trb99P7zBv3zGRUP+POWkIhMCQH99/DPsrCog3djX1Eg/Pvz8vDt7Obc2MXFurq5tJ2Oejk2NQRMzor9AAAEo0lEQVQ4y23UB1QScRzAcaisbJqjvffeewcVRSyBZDhABGQkDkhREMi9TS3T3LkzZ25tamrOzFLbe++93+t/x1n28svv3bt37/Pecfe/OxQKZTJ3XD/Q+Pko1CSTTf3+b9wEoMzGr5hsYGAw2bjfZtOt45cZjNBn8DfjAYBNWGJhgbXAnrcwXjduvbGMwZAxGUQGh0gFB/UzBmJjvWg0hvwwkURzsqM48SgnAigneBQKz9eJRHQgyak06iCI9T8sJxEdHRxoCidfio+dGxkaP1dXHo7k7SsnUUkIo9JcnIOC8uPiCp4KL4UL48NTwCSEFxY8dctRyL1Yh/UMS8S1v7u5b+9eaI4jA+1Ht9d5yxheVIRh7+y+tr2PXh96XMdkcjgIs7j/BtNn2ee+1TFlCKO6JO7CYE7nRu+O3t2r6HNSzLVzj/NIOXrm4JJ0FoO5eEWYGFYs0jx/HpmqjhRp3FXuuVJM9unvfiQ9I7KKdwEmKhSUupdpIiNSU9WpojJVWHx5rjlme02Cr54xvY8Ctv+kIKSjxCNC7fmC4Bmh9ijriI8XHceYH7okGwmxgUwcxGxPCkKtPTw9xWI8XiwmHLSxDw2xtoUYTs9wevYjBCgCHp+ekZGOxwNnHXryLmAhuJGDYcY7dgCwq+4eqWl4rU5XXaWrTMdL1B4ayU2M+ZlSH4S5XgHs4lWVJk2SXqGryszUVevwEkLkz+hsTHZNym2EBYgAuxtV2RkV9fJVV1d3d1f3q5dRnVkfd4Bzhj90Gw4zH8ox8N+u7zmy58iRPT2B/Rvm4JThVo1+euZ84jJgUvMd/2YuxUjPlD+is8m9WF9JT5d/VfL/MFfoSq+/v3Vr57/llls/iQ38cgFh8JXadkq0lZlZWaeiwO9UVlbmrwxJR1FwUGAMwnC8Z/r7FpEm0VZU6zKrqqortZI0G1VyURxgfsgNqYeu1JZQbB/5QqzVZlRUZGjTxWnqEvfE1tgWNzsKYL3WNMTa3saTIMaD4DW1DmmzslQuXYRDnhAm/IRcbgsF7qAnAXQQUqFtj5SWy+fNW7l4FsQYOaEQO1YgSCm2F9nYREaoIzzs3ZMFwfmWgatNJppsMYXfU1byWcCexQYLS5NUZSKNpkRVElYqLIjLp0+ZaTYRDRDEXJIglvQg9olQkJIcFqZKCksuKirMD2piT+k/0QhhWPDKAJb4oCUouLUwQSAEE9waF9vysIk7fCAaPQlh5+9DrJlL599TKq3glMp7fDqbSx493WiSkREaZtjmt9Idn+6QuWw6n28Jx+fTwZqTfXymmZjNGTsBZkTn9hs1CbUXyG557EY6vSmQH0hn53HJFB+ct/HgDc1jNsKM5Pgh2ErW4E8JCOB+dmuMiWHH5HEDKPX+ChmLyPW3gG/vWI6j43nw4ZIrFPW8265+dnYB4MPlzKtV5LCoNC+sCxFmcxa40DgkGpFF825QOPn71vq7gq1Tg9yb5egFjQPMzNaONhxlaDhqFIdDZTCG9WQIHdRvxgxGgUxnzxg6dOiQVcOxWOzoaUOQwJGemTEXBYc2QqPRpjOnLpw6fT76/4y2oXplNnvNLFNU3/0G7BsqpMnuQ18AAAAASUVORK5CYII="></image>';
 
         // Catch a project that contains a null project name
         if (ddd && ddd.name) {
+            validProject = true;
             project_filename = ddd.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
             projXMLcode = ddd.code.substring(42, ddd.code.length);
+            projXMLcode = projXMLcode.substring(0, (projXMLcode.length - 6));
         }
-        else {
-            project_filename = " ";
-            // allow the string to be pruned below and still have a character remaining.
-            // This will cause the code length test to fail and treat this as an empty project.
-            projXMLcode = "1234567";
-        }
-
-        projXMLcode = projXMLcode.substring(0, (projXMLcode.length - 6));
 
         //Weed out empty files
-        if (projXMLcode.length > 3) {
-
-            // a footer to generate a watermark with the project's information at the bottom-right corner of the SVG 
+        if (validProject && projXMLcode.length > 3) {
+            // a footer to generate a watermark with the project's information at the bottom-right corner of the SVG
             // and hold project metadata.
             var SVGfooter = '<text style="font-size:10px;fill:#555;" x="20" y="140">Parallax BlocklyProp Project</text>';
             SVGfooter += '<text style="font-size:10px;fill:#555;" x="20" y="155">User: ' + encodeToValidXml(ddd.user) + '</text>';
@@ -414,6 +410,7 @@ function processProjectData(projectId, listOffset, callbackTrigger) {
             ]);
         } else {
             projCount--;
+            // Add empty project name to UI list of failed or empty projects
             $('#removed-projects')
                 .removeClass('hidden')
                 .html($('#removed-projects').html() + '<br><span style="width:50px;display: inline-block;text-align:right">' + ddd.id.toString(10) + ' -</span> ' + ddd.name);
@@ -452,12 +449,8 @@ function processFileList() {
                     .html('Ready! Downloading...');
                 saveAs(blob, "BlocklyPropProjects.zip"); // 2) trigger the download
                 setTimeout(function () {
-                    $('#downloadProjBtn')
-                        .removeClass('btn-success')
-                        .addClass('btn-primary')
-                        .html('Download My Projects')
-                        .on('click', startProjectsDownload);
-                }, 1500);
+                    hideEmptyProjectList();         // Clean up the UI
+                }, 2000);
             }, function (err) {
                 $("#downloadProjBtn")
                     .removeClass('btn-info')
@@ -466,4 +459,18 @@ function processFileList() {
             });
         }
     }, 1000);
+}
+
+// Empty and hide the failed project list
+// Reset the download button
+function hideEmptyProjectList() {
+    $('#removed-projects')
+        .html(' ')
+        .addClass('hidden');
+
+    $('#downloadProjBtn')
+        .removeClass('btn-success')
+        .addClass('btn-primary')
+        .html('Download My Projects')
+        .on('click', startProjectsDownload);
 }

--- a/project.js
+++ b/project.js
@@ -368,9 +368,21 @@ function getSomeProjects(listOffset) {
 function processProjectData(projectId, listOffset, callbackTrigger) {
     $.get(baseUrl + 'rest/shared/project/editor/' + projectId, function () {}).done(function (ddd) {
         var svgBase = '<svg blocklyprop="blocklypropproject" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="240" width="480" style="font-family:Arial, Helvetica, sans-serif;font-size:20px;"><rect width="480" height="110" style="fill:#eee;stroke:none;" /><text x="100" y="25" fill="#339">NOTE: To convert this file to an SVG</text><text x="100" y="50" fill="#339">image that shows an image of the</text><text x="100" y="75" fill="#339">blocks, open the file in BlocklyProp</text><text x="100" y="100" fill="#339">and resave it as a new file.</text><image height="80" width="80" x="10" y="15" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAApCAMAAAButatJAAAC+lBMVEUAAAAAAAoLS3YGP2QHQGQSZqAGPmEVcLAGPWAYdbkLTHYLTXcYcrUVa6gSZZ8WbKoAGC8XdbgSY5wAFBoAEyEAGCIWbawVcbIGPmIPS3YJRWsONVAAFB4AAAASZqIWaKETaaUNUH0KRm0MS3YKQWYGOVoEOFYDM1AUQmIBIzgAHCsTaKMVcrMOVYUQXI8PXpMMTHYQX5UQU4EPYJgLSXQMTHYMR24KRm4IQmcOVYcRVIQSRGYHP2MIQ2YEMUgAITQAMEj/v4D///8Xdbj09PX6+vumrLUXcLG0v8aQnq8RT3iZoqwSUn0bc7MscKkXbKkfbaj5+voadLUrcKoYaKGlssEbdbcYc7QXcrMucKcXaaQXZZwWYpcUWYkUVoIXdLYYa6aClKQqbKIma6EXZ58YXo8kW4gUWIYcVYERUHobTnT8/f2is8Iic7AbcrAlcq8bb68Wb68rcqwncawqb6eClqYmbKQfa6QWY5oeWIMVV4MiV4EWVIATU38fVX4XTHIRSnCzv8cdc7IecbAYcK0nb6gebKYubaEsap8bZ58mYZIfX48WXY8VW4wfWYUpWYQTVIAYVH8dU30PP2O2wMohc7GSoLCboqwrZ5kfYZMMWY8nX44YXI4fXY0bW4wYWoscW4kgWYgTVocfUXocUHgST3UQTHQWRmkWQ2X29/insb4jcK0YbqyNnKkcaaIaY5gaX5MlXYshXIoNVIgcWYYYWIYjWIUZV4QqV3sWSm8YSG4TSGwXSGsUQGHDyc+5wcq1v8atuMQWdbqcqLUeb6wbbKgQaagkbacub6SGlaEeaKAfZp0NYZwcZZsZYJMWX5EYW5E0Zo8LV4sYWogWVIQVTnsQRGsGOVwLN1jw8fLNz9S2u8KrtMGnrLYbbqsNY6F9jp4XZZ4LXpgjZJcpY5UVYJQvZI0kX40pW4sbVYUgU3sXUnsHPmMMOl7s7e6zvcWmr7mWprWlqrMQcLKdpbBuhpsrZ5smZ5sRXZAvZIw9YoULUoQeSW8bRmvqNATaAAAAQnRSTlMAA5Wciv6e84z8trb99P7zBv3zGRUP+POWkIhMCQH99/DPsrCog3djX1Eg/Pvz8vDt7Obc2MXFurq5tJ2Oejk2NQRMzor9AAAEo0lEQVQ4y23UB1QScRzAcaisbJqjvffeewcVRSyBZDhABGQkDkhREMi9TS3T3LkzZ25tamrOzFLbe++93+t/x1n28svv3bt37/Pecfe/OxQKZTJ3XD/Q+Pko1CSTTf3+b9wEoMzGr5hsYGAw2bjfZtOt45cZjNBn8DfjAYBNWGJhgbXAnrcwXjduvbGMwZAxGUQGh0gFB/UzBmJjvWg0hvwwkURzsqM48SgnAigneBQKz9eJRHQgyak06iCI9T8sJxEdHRxoCidfio+dGxkaP1dXHo7k7SsnUUkIo9JcnIOC8uPiCp4KL4UL48NTwCSEFxY8dctRyL1Yh/UMS8S1v7u5b+9eaI4jA+1Ht9d5yxheVIRh7+y+tr2PXh96XMdkcjgIs7j/BtNn2ee+1TFlCKO6JO7CYE7nRu+O3t2r6HNSzLVzj/NIOXrm4JJ0FoO5eEWYGFYs0jx/HpmqjhRp3FXuuVJM9unvfiQ9I7KKdwEmKhSUupdpIiNSU9WpojJVWHx5rjlme02Cr54xvY8Ctv+kIKSjxCNC7fmC4Bmh9ijriI8XHceYH7okGwmxgUwcxGxPCkKtPTw9xWI8XiwmHLSxDw2xtoUYTs9wevYjBCgCHp+ekZGOxwNnHXryLmAhuJGDYcY7dgCwq+4eqWl4rU5XXaWrTMdL1B4ayU2M+ZlSH4S5XgHs4lWVJk2SXqGryszUVevwEkLkz+hsTHZNym2EBYgAuxtV2RkV9fJVV1d3d1f3q5dRnVkfd4Bzhj90Gw4zH8ox8N+u7zmy58iRPT2B/Rvm4JThVo1+euZ84jJgUvMd/2YuxUjPlD+is8m9WF9JT5d/VfL/MFfoSq+/v3Vr57/llls/iQ38cgFh8JXadkq0lZlZWaeiwO9UVlbmrwxJR1FwUGAMwnC8Z/r7FpEm0VZU6zKrqqortZI0G1VyURxgfsgNqYeu1JZQbB/5QqzVZlRUZGjTxWnqEvfE1tgWNzsKYL3WNMTa3saTIMaD4DW1DmmzslQuXYRDnhAm/IRcbgsF7qAnAXQQUqFtj5SWy+fNW7l4FsQYOaEQO1YgSCm2F9nYREaoIzzs3ZMFwfmWgatNJppsMYXfU1byWcCexQYLS5NUZSKNpkRVElYqLIjLp0+ZaTYRDRDEXJIglvQg9olQkJIcFqZKCksuKirMD2piT+k/0QhhWPDKAJb4oCUouLUwQSAEE9waF9vysIk7fCAaPQlh5+9DrJlL599TKq3glMp7fDqbSx493WiSkREaZtjmt9Idn+6QuWw6n28Jx+fTwZqTfXymmZjNGTsBZkTn9hs1CbUXyG557EY6vSmQH0hn53HJFB+ct/HgDc1jNsKM5Pgh2ErW4E8JCOB+dmuMiWHH5HEDKPX+ChmLyPW3gG/vWI6j43nw4ZIrFPW8265+dnYB4MPlzKtV5LCoNC+sCxFmcxa40DgkGpFF825QOPn71vq7gq1Tg9yb5egFjQPMzNaONhxlaDhqFIdDZTCG9WQIHdRvxgxGgUxnzxg6dOiQVcOxWOzoaUOQwJGemTEXBYc2QqPRpjOnLpw6fT76/4y2oXplNnvNLFNU3/0G7BsqpMnuQ18AAAAASUVORK5CYII="></image>';
-        project_filename = ddd.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+        var project_filename;
+        var projXMLcode;
 
-        var projXMLcode = ddd.code.substring(42, ddd.code.length);
+        // Catch a project that contains a null project name
+        if (ddd && ddd.name) {
+            project_filename = ddd.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+            projXMLcode = ddd.code.substring(42, ddd.code.length);
+        }
+        else {
+            project_filename = " ";
+            // allow the string to be pruned below and still have a character remaining.
+            // This will cause the code length test to fail and treat this as an empty project.
+            projXMLcode = "1234567";
+        }
+
         projXMLcode = projXMLcode.substring(0, (projXMLcode.length - 6));
 
         //Weed out empty files


### PR DESCRIPTION
Trap an illegal null project name and reject the project.

We recently discovered that there is a possibility that one or more projects in the database may contain an null project name field. This created a failure mode in the bulk project export code that expected to always receive a valid project name from the server endpoint.

This patch identifies that exact situation and treats the project an empty. This will cause the project counter to retain the correct count of non-empty projects.