### PR TITLE
Remove empty project listing in UI

### DIFF
--- a/project.js
+++ b/project.js
@@ -419,11 +419,6 @@ function processProjectData(projectId, listOffset, callbackTrigger) {
 
             // Add project to excluded list
             excludedProjects.push([ddd.id.toString(10), ddd.name]);
-
-            // Add empty project name to UI list of failed or empty projects
-            $('#removed-projects')
-                .removeClass('hidden')
-                .html($('#removed-projects').html() + '<br><span style="width:50px;display: inline-block;text-align:right">' + ddd.id.toString(10) + ' -</span> ' + ddd.name);
         }
         if (callbackTrigger == 'final') {
             processFileList();


### PR DESCRIPTION
Removes code that was enumerating any empty or corrupt projects that were encountered while packaging projects for export. The export process now includes a text file that provides this detail.